### PR TITLE
Model persister

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,20 +1,16 @@
+
 cmake_minimum_required(VERSION 3.15)
 project(ToDOlist)
 include_directories(src)
 include_directories(tests)
-
+SET(CMAKE_C_FLAGS_DEBUG "-D_DEBUG")
 set(CMAKE_CXX_STANDARD 17)
+#set(CMAKE_CXX_STANDARD_REQUIRED ON)
+#set(BUILD_SHARED_LIBS OFF)
+
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fprofile-instr-generate -fcoverage-mapping")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fprofile-instr-generate -fcoverage-mapping")
 #set(CMAKE_CXX_FLAGS "-D_GLIBCXX_DEBUG")
-
-file( GLOB_RECURSE CLI_SOURCES src/cli/*.cpp)
-file( GLOB_RECURSE CLI_HEADERS src/cli/*.h)
-file( GLOB_RECURSE CORE_HEADERS src/core/*.h)
-file( GLOB_RECURSE CORE_SOURCES src/core/*.cpp)
-add_executable(ToDOList src/main.cpp
-        ${CLI_SOURCES} ${CLI_HEADERS}
-        ${CORE_SOURCES} ${CORE_HEADERS})
 
 # boost #####################################################
 set(Boost_USE_STATIC_LIBS        ON)  # only find static libs
@@ -24,15 +20,21 @@ set(Boost_USE_MULTITHREADED      ON)
 set(Boost_USE_STATIC_RUNTIME     OFF)
 
 find_package(Boost REQUIRED COMPONENTS date_time)
-
-
 if(Boost_FOUND)
     include_directories(${Boost_INCLUDE_DIRS})
 endif()
 
+find_package(Protobuf REQUIRED)
+include_directories(${Protobuf_INCLUDE_DIRS})
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
-target_link_libraries(ToDOList -static)
-target_link_libraries(ToDOList ${Boost_LIBRARIES})
+file(GLOB_RECURSE PROTO_SOURCES CONFIGURE_DEPENDS ${CMAKE_SOURCE_DIR}/proto/*.proto )
+protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS ${PROTO_SOURCES})
+message("Generated ${PROTO_SRCS} ${PROTO_HDRS}")
+
+SET_SOURCE_FILES_PROPERTIES(${PROTO_SRCS} ${PROTO_HDRS} PROPERTIES GENERATED TRUE)
+
+
 
 ##############################################################
 
@@ -49,6 +51,19 @@ include_directories(tests)
 
 #############################################
 
+
+
+file( GLOB_RECURSE CLI_SOURCES src/cli/*.cpp)
+file( GLOB_RECURSE CLI_HEADERS src/cli/*.h)
+file( GLOB_RECURSE CORE_HEADERS src/core/*.h)
+file( GLOB_RECURSE CORE_SOURCES src/core/*.cpp)
+add_executable(ToDOList src/main.cpp
+        ${CLI_SOURCES} ${CLI_HEADERS}
+        ${CORE_SOURCES} ${CORE_HEADERS}
+        ${PROTO_SRCS} ${PROTO_HDRS})
+target_link_libraries(ToDOList ${Boost_LIBRARIES})
+target_link_libraries(ToDOList -static ${Protobuf_LIBRARIES})
+
 # tests #####################################
 include(GoogleTest)
 find_package(GTest REQUIRED)
@@ -61,8 +76,12 @@ file(GLOB_RECURSE MOCKS tests/mocks/*.h)
 add_executable(TestsExecutable
         ${CLI_SOURCES} ${CLI_HEADERS}
         ${CORE_SOURCES} ${CORE_HEADERS}
-        ${TESTS} ${MOCKS})
-target_link_libraries(TestsExecutable GTest::GTest GTest::Main ${GMOCK_LIBRARY} ${GMOCK_MAIN_LIBRARY} ${Boost_LIBRARIES})
+        ${TESTS} ${MOCKS}
+        ${PROTO_SRCS} ${PROTO_HDRS})
+target_link_libraries(TestsExecutable GTest::GTest GTest::Main
+        ${GMOCK_LIBRARY} ${GMOCK_MAIN_LIBRARY}
+        ${Boost_LIBRARIES})
+target_link_libraries(TestsExecutable ${Protobuf_LIBRARIES})
 
 gtest_discover_tests(TestsExecutable)
 

--- a/proto/task.proto
+++ b/proto/task.proto
@@ -1,3 +1,4 @@
+syntax = "proto3";
 import "google/protobuf/timestamp.proto";
 
 message TaskData {
@@ -7,17 +8,17 @@ message TaskData {
     SECOND = 2;
     THIRD = 3;
   }
-  required string                     name        = 1;
-  required Priority                   prior       = 2;
-  required string                     label       = 3;
-  required google.protobuf.Timestamp  date        = 4;
-  required bool                       completed   = 5;
+  string                     name        = 1;
+  Priority                   prior       = 2;
+  string                     label       = 3;
+  google.protobuf.Timestamp  date        = 4;
+  bool                       completed   = 5;
 
 }
 
 message TaskMessage {
-  required TaskData                   task = 1;
-  repeated TaskMessage                subtasks = 8;
+  TaskData                   task = 1;
+  repeated TaskMessage       subtasks = 8;
 }
 
 message TaskModelMessage {

--- a/proto/task.proto
+++ b/proto/task.proto
@@ -1,0 +1,25 @@
+import "google/protobuf/timestamp.proto";
+
+message TaskData {
+  enum Priority {
+    NONE = 0;
+    FIRST = 1;
+    SECOND = 2;
+    THIRD = 3;
+  }
+  required string                     name        = 1;
+  required Priority                   prior       = 2;
+  required string                     label       = 3;
+  required google.protobuf.Timestamp  date        = 4;
+  required bool                       completed   = 5;
+
+}
+
+message TaskMessage {
+  required TaskData                   task = 1;
+  repeated TaskMessage                subtasks = 8;
+}
+
+message TaskModelMessage {
+  repeated TaskMessage tasks = 1;
+}

--- a/src/core/memory_model/api/TaskModel.cpp
+++ b/src/core/memory_model/api/TaskModel.cpp
@@ -133,3 +133,12 @@ std::vector<TaskDTO> TaskModel::getSubTasksRecursive(TaskID id) const {
 std::vector<TaskDTO> TaskModel::getAllTasks() const {
     return convertAllNodes(storage_->getAllTasks());
 }
+
+std::optional<TaskDTO> TaskModel::getParentTask(TaskID id) const {
+    auto node = storage_->getTaskByID(id).lock();
+    if (!node) {
+        return std::nullopt;
+    }
+    auto parent = node->getParent().lock();
+    return parent ? getTaskData(parent->getId()) : std::nullopt;
+}

--- a/src/core/memory_model/api/TaskModel.h
+++ b/src/core/memory_model/api/TaskModel.h
@@ -35,6 +35,7 @@ public:
     std::vector<TaskDTO>                        getSubTasks(TaskID id) const override;
     std::vector<TaskDTO>                        getSubTasksRecursive(TaskID id) const override;
     std::vector<TaskDTO>                        getAllTasks() const override;
+    std::optional<TaskDTO>                      getParentTask(TaskID id) const override;
 
 private:
     std::unique_ptr<TaskStorageInterface>                   storage_;

--- a/src/core/memory_model/api/TaskModelInterface.h
+++ b/src/core/memory_model/api/TaskModelInterface.h
@@ -105,6 +105,14 @@ public:
      * @return vector of task DTO corresponding to all tasks in system
      */
     virtual std::vector<TaskDTO>                        getAllTasks() const = 0;
+    /*
+     * Gives task which has a task with the given id as subtask,
+     * or nothig if such does not exits. In terms of tree, method
+     * gives a parent of the task.
+     *
+     * @return parent of task or nullopt if there is no.
+     */
+    virtual std::optional<TaskDTO>                      getParentTask(TaskID id) const = 0;
 
     virtual                                             ~TaskModelInterface() = default;
 };

--- a/src/core/persistence/IostreamModelPersister.cpp
+++ b/src/core/persistence/IostreamModelPersister.cpp
@@ -77,8 +77,8 @@ bool IostreamModelPersister::Load(TaskModelInterface &model) {
     return true;
 }
 
-void IostreamModelPersister::setStream(const std::shared_ptr<std::iostream>& stream) {
-    stream_ = stream;
+void IostreamModelPersister::SetStream(std::unique_ptr<std::iostream> stream) {
+    stream_ = std::move(stream);
 }
 
 

--- a/src/core/persistence/IostreamModelPersister.cpp
+++ b/src/core/persistence/IostreamModelPersister.cpp
@@ -1,0 +1,84 @@
+//
+// Created by denis on 30.09.20.
+//
+
+#include "IostreamModelPersister.h"
+#include "core/memory_model/view/DatePriorityView.h"
+#include "core/memory_model/view/TagPriorityView.h"
+#include "core/memory_model/data/TaskStorage.h"
+#include "core/memory_model/structure/LinkManager.h"
+#include "core/memory_model/api/TaskModel.h"
+
+IostreamModelPersister::IostreamModelPersister
+        (std::unique_ptr<TaskDataConverterInterface> data_converter)
+        :
+        data_converter_(std::move(data_converter))
+{}
+
+bool IostreamModelPersister::WriteTaskToTaskMessage(const TaskModelInterface& model, const TaskDTO& task, TaskMessage* message) {
+    message->set_allocated_task(new TaskData);
+    data_converter_->WriteToMessage(task, message->mutable_task());
+    for (const auto& subtask : model.getSubTasks(task.getId())) {
+        TaskMessage* subtask_dump = message->add_subtasks();
+        if (!WriteTaskToTaskMessage(model, subtask, subtask_dump)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool IostreamModelPersister::Save(const TaskModelInterface &model) {
+    TaskModelMessage assembled_model_message;
+    for (const auto& task : model.getAllTasks()) {
+        if (!model.getParentTask(task.getId())) {
+            TaskMessage* assembled_task_message = assembled_model_message.add_tasks();
+            if (!WriteTaskToTaskMessage(model, task, assembled_task_message)) {
+                return false;
+            }
+        }
+    }
+    return assembled_model_message.SerializeToOstream(stream_.get());
+}
+
+bool IostreamModelPersister::RestoreTaskByMessage(TaskModelInterface& model, TaskID id, const TaskMessage& message) {
+    for (const TaskMessage& subtask_load : message.subtasks()) {
+        TaskDTO subtask = data_converter_->RestoreFromMessage(subtask_load.task());
+        TaskCreationResult result = model.addSubTask(id, subtask);
+        if (!result.getCreatedTaskID()) {
+            return false;
+        }
+        TaskID id_subtask = result.getCreatedTaskID().value();
+        if (!RestoreTaskByMessage(model, id_subtask, subtask_load)) {
+            // failed to deserialize subtasks hierarchy at any point
+            return false;
+        }
+    }
+    // all is OK
+    return true;
+}
+
+bool IostreamModelPersister::Load(TaskModelInterface &model) {
+    TaskModelMessage loaded_model;
+    if (!loaded_model.ParseFromIstream(stream_.get())) {
+        return false;
+    }
+    for (const TaskMessage& task_load : loaded_model.tasks()) {
+        TaskDTO task = data_converter_->RestoreFromMessage(task_load.task());
+        TaskCreationResult result = model.addTask(task);
+
+        if (!result.getCreatedTaskID()) {
+            return false;
+        }
+        if (!RestoreTaskByMessage(model, result.getCreatedTaskID().value(), task_load)) {
+            // failed to deserialize subtasks hierarchy at any point
+            return false;
+        }
+    }
+    return true;
+}
+
+void IostreamModelPersister::setStream(const std::shared_ptr<std::iostream>& stream) {
+    stream_ = stream;
+}
+
+

--- a/src/core/persistence/IostreamModelPersister.h
+++ b/src/core/persistence/IostreamModelPersister.h
@@ -17,8 +17,8 @@ public:
 
 public:
     bool                                Save(const TaskModelInterface &model) override;
-    bool Load(TaskModelInterface &model) override;
-    void                                setStream(const std::shared_ptr<std::iostream>&) override;
+    bool                                Load(TaskModelInterface &model) override;
+    void                                SetStream(std::unique_ptr<std::iostream>) override;
 
 private:
     bool RestoreTaskByMessage(TaskModelInterface& model, TaskID id, const TaskMessage& message);

--- a/src/core/persistence/IostreamModelPersister.h
+++ b/src/core/persistence/IostreamModelPersister.h
@@ -1,0 +1,34 @@
+//
+// Created by denis on 30.09.20.
+//
+
+#ifndef TODOLIST_IOSTREAMMODELPERSISTER_H
+#define TODOLIST_IOSTREAMMODELPERSISTER_H
+
+#include "ModelPersister.h"
+#include "StreamOwner.h"
+#include "TaskDataConverterInterface.h"
+#include "task.pb.h"
+
+class IostreamModelPersister : public ModelPersister, public StreamOwner {
+
+public:
+    explicit IostreamModelPersister(std::unique_ptr<TaskDataConverterInterface> data_converter);
+
+public:
+    bool                                Save(const TaskModelInterface &model) override;
+    bool Load(TaskModelInterface &model) override;
+    void                                setStream(const std::shared_ptr<std::iostream>&) override;
+
+private:
+    bool RestoreTaskByMessage(TaskModelInterface& model, TaskID id, const TaskMessage& message);
+    bool WriteTaskToTaskMessage(const TaskModelInterface& model, const TaskDTO& task, TaskMessage* message);
+
+private:
+    std::unique_ptr<TaskDataConverterInterface> data_converter_;
+    std::shared_ptr<std::iostream> stream_;
+};
+
+
+
+#endif //TODOLIST_IOSTREAMMODELPERSISTER_H

--- a/src/core/persistence/ModelPersister.h
+++ b/src/core/persistence/ModelPersister.h
@@ -1,0 +1,18 @@
+//
+// Created by denis on 30.09.20.
+//
+
+#ifndef TODOLIST_MODELPERSISTER_H
+#define TODOLIST_MODELPERSISTER_H
+
+#include "core/memory_model/api/TaskModelInterface.h"
+
+class ModelPersister {
+
+public:
+    virtual bool Save(const TaskModelInterface &object) = 0;
+    virtual bool Load(TaskModelInterface &model) = 0;
+    virtual ~ModelPersister() = default;
+};
+
+#endif //TODOLIST_PROTOBUFMODELPERSISTER_H

--- a/src/core/persistence/StreamOwner.h
+++ b/src/core/persistence/StreamOwner.h
@@ -1,0 +1,18 @@
+//
+// Created by denis on 30.09.20.
+//
+
+#ifndef TODOLIST_FILESTREAMSOURCE_H
+#define TODOLIST_FILESTREAMSOURCE_H
+
+#include <iostream>
+
+class StreamOwner {
+
+public:
+    virtual void setStream(const std::shared_ptr<std::iostream>&) = 0;
+    virtual ~StreamOwner() = default;
+};
+
+
+#endif //TODOLIST_FILESTREAMSOURCE_H

--- a/src/core/persistence/StreamOwner.h
+++ b/src/core/persistence/StreamOwner.h
@@ -10,7 +10,7 @@
 class StreamOwner {
 
 public:
-    virtual void setStream(const std::shared_ptr<std::iostream>&) = 0;
+    virtual void SetStream(std::unique_ptr<std::iostream>) = 0;
     virtual ~StreamOwner() = default;
 };
 

--- a/src/core/persistence/TaskDataConverter.cpp
+++ b/src/core/persistence/TaskDataConverter.cpp
@@ -43,6 +43,8 @@ TaskPriority RestorePriority(TaskData::Priority prior) {
             return TaskPriority::THIRD;
         case TaskData::NONE:
             return TaskPriority::NONE;
+        default:
+            return TaskPriority::NONE;
     }
 }
 

--- a/src/core/persistence/TaskDataConverter.cpp
+++ b/src/core/persistence/TaskDataConverter.cpp
@@ -1,0 +1,67 @@
+//
+// Created by denis on 30.09.20.
+//
+
+#include "TaskDataConverter.h"
+
+std::unique_ptr<google::protobuf::Timestamp> GetProtobufDate(const BoostDate& date) {
+    using namespace boost::posix_time;
+    ptime datetime(date);
+    ptime epoch(BoostDate(1970, 1, 1));
+    auto timestamp = std::make_unique<google::protobuf::Timestamp>();
+    time_t diff_epoch = (datetime - epoch).total_seconds();
+    timestamp->set_seconds(diff_epoch);
+    return timestamp;
+}
+
+BoostDate RestoreDate(const google::protobuf::Timestamp &time_load) {
+    using namespace boost::posix_time;
+    ptime datetime = from_time_t(time_load.seconds());
+    return datetime.date();
+}
+
+
+TaskData::Priority GetProtobufPriority(TaskPriority prior) {
+    switch (prior) {
+        case TaskPriority::FIRST:
+            return TaskData::FIRST;
+        case TaskPriority::SECOND:
+            return TaskData::SECOND;
+        case TaskPriority::THIRD:
+            return TaskData::THIRD;
+        case TaskPriority::NONE:
+            return TaskData::NONE;
+    }
+}
+TaskPriority RestorePriority(TaskData::Priority prior) {
+    switch (prior) {
+        case TaskData::FIRST:
+            return TaskPriority::FIRST;
+        case TaskData::SECOND:
+            return TaskPriority::SECOND;
+        case TaskData::THIRD:
+            return TaskPriority::THIRD;
+        case TaskData::NONE:
+            return TaskPriority::NONE;
+    }
+}
+
+/********************************************************************************/
+
+TaskDTO TaskDataConverter::RestoreFromMessage(const TaskData &message) {
+    return TaskDTO::create(TaskID(0),
+                           message.name(),
+                           RestorePriority(message.prior()),
+                           message.label(),
+                           RestoreDate(message.date()),
+                           message.completed());
+}
+
+bool TaskDataConverter::WriteToMessage(const TaskDTO &task, TaskData *message) {
+    message->set_name(task.getName());
+    message->set_prior(GetProtobufPriority(task.getPriority()));
+    message->set_label(task.getLabel());
+    message->set_allocated_date(GetProtobufDate(task.getDate()).release());
+    message->set_completed(task.isCompleted());
+    return true;
+}

--- a/src/core/persistence/TaskDataConverter.h
+++ b/src/core/persistence/TaskDataConverter.h
@@ -1,0 +1,22 @@
+//
+// Created by denis on 30.09.20.
+//
+
+#ifndef TODOLIST_TASKDATACONVERTER_H
+#define TODOLIST_TASKDATACONVERTER_H
+
+#include "TaskDataConverterInterface.h"
+
+class TaskDataConverter : public TaskDataConverterInterface {
+
+public:
+    TaskDTO             RestoreFromMessage(const TaskData& message) override;
+    bool                WriteToMessage(const TaskDTO &data, TaskData *message) override;
+};
+
+std::unique_ptr<google::protobuf::Timestamp> GetProtobufDate(const BoostDate& date);
+BoostDate RestoreDate(const google::protobuf::Timestamp& time_load);
+TaskData::Priority GetProtobufPriority(TaskPriority prior);
+TaskPriority RestorePriority(TaskData::Priority prior);
+
+#endif //TODOLIST_TASKDATACONVERTER_H

--- a/src/core/persistence/TaskDataConverterInterface.h
+++ b/src/core/persistence/TaskDataConverterInterface.h
@@ -1,0 +1,20 @@
+//
+// Created by denis on 30.09.20.
+//
+
+#ifndef TODOLIST_TASKDATACONVERTERINTERFACE_H
+#define TODOLIST_TASKDATACONVERTERINTERFACE_H
+
+#include "task.pb.h"
+#include "core/memory_model/api/TaskModelInterface.h"
+
+class TaskDataConverterInterface {
+
+public:
+    virtual TaskDTO     RestoreFromMessage(const TaskData& message) = 0;
+    virtual bool        WriteToMessage(const TaskDTO &data, TaskData *message) = 0;
+    virtual ~TaskDataConverterInterface() = default;
+};
+
+
+#endif //TODOLIST_TASKDATACONVERTERINTERFACE_H

--- a/tests/core/persistence/TestIostreamModelPersister.cpp
+++ b/tests/core/persistence/TestIostreamModelPersister.cpp
@@ -89,9 +89,9 @@ TEST_F(IostreamModelPersisterTest, TestDemanglesAllSubtasks) {
     }
     IostreamModelPersister iosmp(std::move(mtd));
 
-    auto ss = std::make_shared<std::stringstream>(std::ios::out | std::ios::in);
+    auto ss = std::make_unique<std::stringstream>(std::ios::out | std::ios::in);
     model_proto.SerializeToOstream(ss.get());
-    iosmp.setStream(ss);
+    iosmp.SetStream(std::move(ss));
     ASSERT_TRUE(iosmp.Load(mm));
 }
 
@@ -153,6 +153,6 @@ TEST_F(IostreamModelPersisterTest, TestSerializesAllSubtasks) {
         ).Times(1);
     }
     IostreamModelPersister sr(std::move(mts));
-    sr.setStream(std::make_shared<std::stringstream>());
+    sr.SetStream(std::make_unique<std::stringstream>());
     sr.Save(ms);
 }

--- a/tests/core/persistence/TestIostreamModelPersister.cpp
+++ b/tests/core/persistence/TestIostreamModelPersister.cpp
@@ -1,0 +1,158 @@
+//
+// Created by denis on 30.09.20.
+//
+
+#include "mocks/CoreMocks.h"
+#include "mocks/MockTaskDataConverter.h"
+#include "core/persistence/IostreamModelPersister.h"
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+
+#include "core/api/TODOList.h"
+using ::testing::NiceMock;
+using ::testing::Return;
+using ::testing::Truly;
+using ::testing::_;
+
+class IostreamModelPersisterTest : public ::testing::Test {
+
+};
+
+#define DUMMY_TASK_FIELDS "name", TaskPriority::FIRST, "label", boost::gregorian::day_clock::local_day()
+#define DUMMY_TAIL  TaskPriority::FIRST, "label", boost::gregorian::day_clock::local_day()
+
+void fill_task(TaskData* task, std::string name) {
+    task->set_name(name);
+    task->set_prior(TaskData::THIRD);
+    task->set_label("label");
+    task->set_allocated_date(::google::protobuf::Timestamp().New());
+    task->set_completed(true);
+}
+
+auto has_name(std::string str) {
+    return Truly([str] (const TaskDTO& dto) {
+        return dto.getName() == str;
+    });
+}
+
+TEST_F(IostreamModelPersisterTest, TestDemanglesAllSubtasks) {
+    MockModel mm;
+    TaskModelMessage model_proto;
+    TaskMessage* task1 = model_proto.add_tasks();
+    task1->set_allocated_task(new TaskData);
+    fill_task(task1->mutable_task(), "1");
+    EXPECT_CALL(mm, addTask(Truly([] (const TaskDTO& dto) {
+        return dto.getName() == "1";
+    })))
+            .WillOnce(Return(TaskCreationResult::success(TaskID(0))));
+    TaskMessage* task2 = model_proto.add_tasks();
+    task2->set_allocated_task(new TaskData);
+    fill_task(task2->mutable_task(), "2");
+    EXPECT_CALL(mm, addTask(has_name("2")))
+            .WillOnce(Return(TaskCreationResult::success(TaskID(1))));
+    TaskMessage* task3 = model_proto.add_tasks();
+    task3->set_allocated_task(new TaskData);
+    fill_task(task3->mutable_task(), "3");
+    EXPECT_CALL(mm, addTask(has_name("3")))
+            .WillOnce(Return(TaskCreationResult::success(TaskID(2))));
+    TaskMessage* task11 = task1->add_subtasks();
+    task11->set_allocated_task(new TaskData);
+    fill_task(task11->mutable_task(), "11");
+    EXPECT_CALL(mm, addSubTask(TaskID(0), has_name("11")))
+            .WillOnce(Return(TaskCreationResult::success(TaskID(3))));
+    TaskMessage* task12 = task1->add_subtasks();
+    task12->set_allocated_task(new TaskData);
+    fill_task(task12->mutable_task(), "12");
+    EXPECT_CALL(mm, addSubTask(TaskID(0), has_name("12")))
+            .WillOnce(Return(TaskCreationResult::success(TaskID(4))));
+    TaskMessage* task13 = task1->add_subtasks();
+    task13->set_allocated_task(new TaskData);
+    fill_task(task13->mutable_task(), "13");
+    EXPECT_CALL(mm, addSubTask(TaskID(0), has_name("13")))
+            .WillOnce(Return(TaskCreationResult::success(TaskID(5))));
+    TaskMessage* task121 = task12->add_subtasks();
+    task121->set_allocated_task(new TaskData);
+    fill_task(task121->mutable_task(), "121");
+    EXPECT_CALL(mm, addSubTask(TaskID(4), has_name("121")))
+            .WillOnce(Return(TaskCreationResult::success(TaskID(6))));
+    std::vector protos {task1, task11, task12, task121, task13, task2, task3};
+    auto mtd = std::make_unique<MockTaskDataConverter>();
+    for (auto pts : protos) {
+        auto nm = pts->task().name();
+        EXPECT_CALL(*mtd,
+                RestoreFromMessage(Truly([nm] (const TaskData& pts1) {return pts1.name() == nm;})))
+                .Times(1)
+                .WillOnce(Return(
+                        TaskDTO::create(nm, DUMMY_TAIL))
+                );
+    }
+    IostreamModelPersister iosmp(std::move(mtd));
+
+    auto ss = std::make_shared<std::stringstream>(std::ios::out | std::ios::in);
+    model_proto.SerializeToOstream(ss.get());
+    iosmp.setStream(ss);
+    ASSERT_TRUE(iosmp.Load(mm));
+}
+
+std::vector<TaskDTO> on_indexes(const std::vector<TaskDTO>& vec, const std::vector<std::size_t>& indexes) {
+    std::vector<TaskDTO> vec_filter;
+    for (std::size_t index : indexes) {
+        vec_filter.push_back(vec[index]);
+    }
+    return vec_filter;
+};
+
+
+TEST_F(IostreamModelPersisterTest, TestSerializesAllSubtasks) {
+    std::vector sample_tasks {
+            TaskDTO::create(TaskID(0), DUMMY_TASK_FIELDS, false),
+            TaskDTO::create(TaskID(1), DUMMY_TASK_FIELDS, false),
+            TaskDTO::create(TaskID(2), DUMMY_TASK_FIELDS, false),
+            TaskDTO::create(TaskID(3), DUMMY_TASK_FIELDS, false),
+            TaskDTO::create(TaskID(4), DUMMY_TASK_FIELDS, false),
+            TaskDTO::create(TaskID(5), DUMMY_TASK_FIELDS, false),
+            TaskDTO::create(TaskID(6), DUMMY_TASK_FIELDS, false),
+            TaskDTO::create(TaskID(7), DUMMY_TASK_FIELDS, false)
+
+    };
+    MockModel ms;
+    EXPECT_CALL(ms, getAllTasks).WillRepeatedly(Return(sample_tasks));
+    EXPECT_CALL(ms, getParentTask(TaskID(0))).Times(1).WillOnce(Return(std::nullopt));
+    EXPECT_CALL(ms, getParentTask(TaskID(1))).Times(1).WillOnce(Return(sample_tasks[0]));
+    EXPECT_CALL(ms, getParentTask(TaskID(2))).Times(1).WillOnce(Return(sample_tasks[0]));
+    EXPECT_CALL(ms, getParentTask(TaskID(3))).Times(1).WillOnce(Return(sample_tasks[0]));
+    EXPECT_CALL(ms, getParentTask(TaskID(4))).Times(1).WillOnce(Return(sample_tasks[1]));
+    EXPECT_CALL(ms, getParentTask(TaskID(5))).Times(1).WillOnce(Return(sample_tasks[1]));
+    EXPECT_CALL(ms, getParentTask(TaskID(6))).Times(1).WillOnce(Return(sample_tasks[5]));
+    EXPECT_CALL(ms, getParentTask(TaskID(7))).Times(1).WillOnce(Return(std::nullopt));
+    // tasks
+    EXPECT_CALL(ms, getAllTasks).WillRepeatedly(Return(sample_tasks));
+    // structure
+    EXPECT_CALL(ms, getSubTasks(sample_tasks[0].getId()))
+            .WillRepeatedly(Return(on_indexes(sample_tasks, {1, 2, 3})));
+    EXPECT_CALL(ms, getSubTasks(sample_tasks[1].getId()))
+            .WillRepeatedly(Return(on_indexes(sample_tasks, {4, 5})));
+    EXPECT_CALL(ms, getSubTasks(sample_tasks[2].getId()))
+            .WillRepeatedly(Return(std::vector<TaskDTO> {}));
+    EXPECT_CALL(ms, getSubTasks(sample_tasks[3].getId()))
+            .WillRepeatedly(Return(std::vector<TaskDTO> {}));
+    EXPECT_CALL(ms, getSubTasks(sample_tasks[4].getId()))
+            .WillRepeatedly(Return(std::vector<TaskDTO> {}));
+    EXPECT_CALL(ms, getSubTasks(sample_tasks[5].getId()))
+            .WillRepeatedly(Return(on_indexes(sample_tasks, {6})));
+    EXPECT_CALL(ms, getSubTasks(sample_tasks[6].getId()))
+            .WillRepeatedly(Return(std::vector<TaskDTO> {}));
+    EXPECT_CALL(ms, getSubTasks(sample_tasks[7].getId()))
+            .WillRepeatedly(Return(std::vector<TaskDTO> {}));
+
+    auto mts = std::make_unique<MockTaskDataConverter>();
+    for (const TaskDTO& dto : sample_tasks) {
+        EXPECT_CALL(*mts,
+                    WriteToMessage(Truly([&dto] (const TaskDTO& dto1) {return dto1.getId() == dto.getId();}), _)
+        ).Times(1);
+    }
+    IostreamModelPersister sr(std::move(mts));
+    sr.setStream(std::make_shared<std::stringstream>());
+    sr.Save(ms);
+}

--- a/tests/core/persistence/TestTaskDataConverter.cpp
+++ b/tests/core/persistence/TestTaskDataConverter.cpp
@@ -1,0 +1,46 @@
+//
+// Created by denis on 30.09.20.
+//
+
+#include "core/persistence/TaskDataConverter.h"
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+
+class TestTaskDataConverter : public ::testing::Test {
+
+};
+
+TEST_F(TestTaskDataConverter, TestAllRestoredFieldsSet) {
+    TaskDataConverter tdc;
+    TaskData proto;
+    proto.set_name("name");
+    proto.set_prior(TaskData::THIRD);
+    proto.set_label("label");
+    proto.set_allocated_date(::google::protobuf::Timestamp().New());
+    proto.set_completed(true);
+    TaskDTO task = tdc.RestoreFromMessage(proto);
+    ASSERT_EQ(proto.name(), task.getName());
+    ASSERT_EQ(RestorePriority(proto.prior()), task.getPriority());
+    ASSERT_EQ(proto.label(), task.getLabel());
+    ASSERT_EQ(RestoreDate(proto.date()), task.getDate());
+    ASSERT_EQ(proto.completed(), task.isCompleted());
+}
+
+TEST_F(TestTaskDataConverter, TestAllWrittenFieldsSet) {
+    TaskDataConverter pts;
+    TaskData proto;
+    auto task = TaskDTO::create( TaskID(1),
+                                 "name",
+                                 TaskPriority::SECOND,
+                                 "label",
+                                 boost::gregorian::day_clock::local_day(),
+                                 true);
+    pts.WriteToMessage(task, &proto);
+    ASSERT_EQ(proto.name(), task.getName());
+    ASSERT_EQ(proto.prior(), GetProtobufPriority(task.getPriority()));
+    ASSERT_EQ(proto.label(), task.getLabel());
+    ASSERT_EQ(proto.date().seconds(), GetProtobufDate(task.getDate())->seconds());
+    ASSERT_EQ(proto.completed(), task.isCompleted());
+}

--- a/tests/mocks/CoreMocks.h
+++ b/tests/mocks/CoreMocks.h
@@ -64,6 +64,8 @@ public:
     MOCK_METHOD(std::vector<TaskDTO>,   getSubTasks, (TaskID id), (const, override));
     MOCK_METHOD(std::vector<TaskDTO>,   getSubTasksRecursive, (TaskID id), (const, override));
     MOCK_METHOD(std::vector<TaskDTO>,   getAllTasks, (), (const, override));
+    MOCK_METHOD(std::optional<TaskDTO>, getParentTask, (TaskID id), (const, override));
+
 };
 
 #endif //TODOLIST_MOCKS_H

--- a/tests/mocks/MockModelPersister.h
+++ b/tests/mocks/MockModelPersister.h
@@ -1,0 +1,20 @@
+//
+// Created by denis on 30.09.20.
+//
+
+#ifndef TODOLIST_MOCKPERSISTER_H
+#define TODOLIST_MOCKPERSISTER_H
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include "core/persistence/ModelPersister.h"
+
+class MockModelPersister : public ModelPersister {
+
+public:
+    MOCK_METHOD(bool, Save, (const TaskModelInterface &object), (override));
+    MOCK_METHOD(bool, Load, (TaskModelInterface&), (override));
+};
+
+
+#endif //TODOLIST_MOCKPERSISTER_H

--- a/tests/mocks/MockTaskDataConverter.h
+++ b/tests/mocks/MockTaskDataConverter.h
@@ -1,0 +1,20 @@
+//
+// Created by denis on 30.09.20.
+//
+
+#ifndef TODOLIST_MOCKTASKDATACONVERTER_H
+#define TODOLIST_MOCKTASKDATACONVERTER_H
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include "core/persistence/TaskDataConverterInterface.h"
+
+class MockTaskDataConverter : public TaskDataConverterInterface {
+
+public:
+    MOCK_METHOD(TaskDTO, RestoreFromMessage, (const TaskData& message), (override));
+    MOCK_METHOD(bool   , WriteToMessage, (const TaskDTO &data, TaskData *message), (override));
+};
+
+
+#endif //TODOLIST_MOCKTASKDATACONVERTER_H


### PR DESCRIPTION
Slightly modifed model to make it support getting parent task.
Added proto description of tasks and model.
Added ifor persistence of model : ModelPersister.
Also added interface StreamOwner for setting iostream for serialization.
Implemented them as IostreamModelPersister which is both ModelPersister and StreamOwner and serializes model to protobuf.
This class reqiures TaskDataConverter to convert data between protobuf and core classes.
