### PR TITLE
Save/load method in task service

### DIFF
--- a/src/core/ModelHolder.cpp
+++ b/src/core/ModelHolder.cpp
@@ -10,12 +10,14 @@ ModelHolder::ModelHolder(
         StreamOwner &persistence_stream) :
         creator_(std::move(creator)),
         persister_(std::move(persister)),
-        persistence_stream_(persistence_stream),
-        model_(creator_->CreateModel())
+        persistence_stream_(persistence_stream)
         {}
 
 
 TaskModelInterface &ModelHolder::GetModel() {
+    if (!model_) {
+        model_ = creator_->CreateModel();
+    }
     return *model_;
 }
 

--- a/src/core/ModelHolder.cpp
+++ b/src/core/ModelHolder.cpp
@@ -5,19 +5,18 @@
 #include "ModelHolder.h"
 
 ModelHolder::ModelHolder(
-        std::unique_ptr<ModelCreator> creator,
+        std::unique_ptr<ModelCreatorInterface> creator,
         std::unique_ptr<ModelPersister> persister,
         StreamOwner &persistence_stream) :
         creator_(std::move(creator)),
         persister_(std::move(persister)),
         persistence_stream_(persistence_stream)
-        {}
+        {
+            model_ = creator_->CreateModel();
+        }
 
 
 TaskModelInterface &ModelHolder::GetModel() {
-    if (!model_) {
-        model_ = creator_->CreateModel();
-    }
     return *model_;
 }
 

--- a/src/core/ModelHolder.cpp
+++ b/src/core/ModelHolder.cpp
@@ -1,0 +1,44 @@
+//
+// Created by denis on 04.10.20.
+//
+
+#include "ModelHolder.h"
+
+ModelHolder::ModelHolder(
+        std::unique_ptr<ModelCreator> creator,
+        std::unique_ptr<ModelPersister> persister,
+        StreamOwner &persistence_stream) :
+        creator_(std::move(creator)),
+        persister_(std::move(persister)),
+        persistence_stream_(persistence_stream),
+        model_(creator_->CreateModel())
+        {}
+
+
+TaskModelInterface &ModelHolder::GetModel() {
+    return *model_;
+}
+
+bool ModelHolder::LoadModelFromFile(const std::string &filepath) {
+    auto file = std::make_unique<std::fstream>(filepath, std::ios::in);
+    if (!file->is_open()) {
+        return false;
+    }
+    auto new_model = creator_->CreateModel();
+    persistence_stream_.SetStream(std::move(file));
+    if (!persister_->Load(*new_model)) {
+        return false;
+    }
+    std::swap(model_, new_model);
+    return true;
+}
+
+bool ModelHolder::SaveModelToFile(const std::string &filepath) {
+    auto file = std::make_unique<std::fstream>(filepath, std::ios::out);
+    if (!file->is_open()) {
+        return false;
+    }
+    persistence_stream_.SetStream(std::move(file));
+    return persister_->Save(*model_);
+}
+

--- a/src/core/ModelHolder.h
+++ b/src/core/ModelHolder.h
@@ -8,13 +8,13 @@
 #include "ModelHolderInterface.h"
 #include "persistence/ModelPersister.h"
 #include "persistence/StreamOwner.h"
-#include "memory_model/ModelCreator.h"
+#include "memory_model/ModelCreatorInterface.h"
 
 class ModelHolder : public ModelHolderInterface {
 
 public:
     explicit ModelHolder(
-            std::unique_ptr<ModelCreator> creator,
+            std::unique_ptr<ModelCreatorInterface> creator,
             std::unique_ptr<ModelPersister> persister,
             StreamOwner& persistence_stream);
 
@@ -25,7 +25,7 @@ public:
 
 private:
     std::unique_ptr<TaskModelInterface> model_;
-    std::unique_ptr<ModelCreator> creator_;
+    std::unique_ptr<ModelCreatorInterface> creator_;
     std::unique_ptr<ModelPersister> persister_;
     StreamOwner& persistence_stream_;
 

--- a/src/core/ModelHolder.h
+++ b/src/core/ModelHolder.h
@@ -1,0 +1,35 @@
+//
+// Created by denis on 04.10.20.
+//
+
+#ifndef TODOLIST_MODELHOLDER_H
+#define TODOLIST_MODELHOLDER_H
+
+#include "ModelHolderInterface.h"
+#include "persistence/ModelPersister.h"
+#include "persistence/StreamOwner.h"
+#include "memory_model/ModelCreator.h"
+
+class ModelHolder : public ModelHolderInterface {
+
+public:
+    explicit ModelHolder(
+            std::unique_ptr<ModelCreator> creator,
+            std::unique_ptr<ModelPersister> persister,
+            StreamOwner& persistence_stream);
+
+public:
+    TaskModelInterface&     GetModel() override;
+    bool                    LoadModelFromFile(const std::string& filepath) override;
+    bool                    SaveModelToFile(const std::string& filepath) override;
+
+private:
+    std::unique_ptr<TaskModelInterface> model_;
+    std::unique_ptr<ModelCreator> creator_;
+    std::unique_ptr<ModelPersister> persister_;
+    StreamOwner& persistence_stream_;
+
+};
+
+
+#endif //TODOLIST_MODELHOLDER_H

--- a/src/core/ModelHolderInterface.h
+++ b/src/core/ModelHolderInterface.h
@@ -1,0 +1,19 @@
+//
+// Created by denis on 04.10.20.
+//
+
+#ifndef TODOLIST_MODELHOLDERINTERFACE_H
+#define TODOLIST_MODELHOLDERINTERFACE_H
+
+#include "memory_model/api/TaskModelInterface.h"
+
+class ModelHolderInterface {
+
+public:
+    virtual TaskModelInterface&     GetModel() = 0;
+    virtual bool                    LoadModelFromFile(const std::string& filepath) = 0;
+    virtual bool                    SaveModelToFile(const std::string& filepath) = 0;
+};
+
+
+#endif //TODOLIST_MODELHOLDERINTERFACE_H

--- a/src/core/ModelHolderInterface.h
+++ b/src/core/ModelHolderInterface.h
@@ -13,6 +13,7 @@ public:
     virtual TaskModelInterface&     GetModel() = 0;
     virtual bool                    LoadModelFromFile(const std::string& filepath) = 0;
     virtual bool                    SaveModelToFile(const std::string& filepath) = 0;
+    virtual ~ModelHolderInterface() = default;
 };
 
 

--- a/src/core/api/TODOList.cpp
+++ b/src/core/api/TODOList.cpp
@@ -5,17 +5,15 @@
 #include "TODOList.h"
 
 std::unique_ptr<TaskServiceInterface> todo_list::createService() {
-    auto storage =      std::make_unique<TaskStorage>();
-    auto view_time =    std::make_unique<DatePriorityView>();
-    auto view_label =   std::make_unique<TagPriorityView>();
-    auto handler =      std::make_unique<LinkManager>(*view_time, *view_label);
-
+    auto creator =      std::make_unique<ModelCreator>();
+    auto persister =    std::make_unique<IostreamModelPersister>(
+                            std::make_unique<TaskDataConverter>()
+                        );
+    StreamOwner& persistence_stream = *persister;
+    auto holder =       std::make_unique<ModelHolder>(
+                            std::move(creator),
+                            std::move(persister),
+                            persistence_stream);
     return
-    std::make_unique<TaskService>(
-            std::make_unique<TaskModel>(
-                std::move(storage),
-                std::move(view_time),
-                std::move(view_label),
-                std::move(handler))
-    );
+    std::make_unique<TaskService>(std::move(holder));
 }

--- a/src/core/api/TODOList.h
+++ b/src/core/api/TODOList.h
@@ -6,11 +6,10 @@
 #define TODOLIST_TODOLIST_H
 
 #include "TaskService.h"
-#include "core/memory_model/view/DatePriorityView.h"
-#include "core/memory_model/view/TagPriorityView.h"
-#include "core/memory_model/data/TaskStorage.h"
-#include "core/memory_model/structure/LinkManager.h"
-#include "core/memory_model/api/TaskModel.h"
+#include "core/memory_model/ModelCreator.h"
+#include "core/persistence/IostreamModelPersister.h"
+#include "core/persistence/TaskDataConverter.h"
+#include "core/ModelHolder.h"
 
 /*
  * TaskService injector

--- a/src/core/api/TaskService.cpp
+++ b/src/core/api/TaskService.cpp
@@ -63,12 +63,13 @@ std::optional<TaskDTO> TaskService::getTaskByID(TaskID id) {
 }
 
 RequestResult TaskService::complete(TaskID id) {
-    auto root_complete_result = model_holder_->GetModel().setCompleted(id);
+    TaskModelInterface& model = model_holder_->GetModel();
+    auto root_complete_result = model.setCompleted(id);
     if (!root_complete_result.getSuccessStatus()) {
         return root_complete_result;
     }
-    for (const auto& task : model_holder_->GetModel().getSubTasksRecursive(id)) {
-        auto complete_result = model_holder_->GetModel().setCompleted(task.getId());
+    for (const auto& task : model.getSubTasksRecursive(id)) {
+        auto complete_result = model.setCompleted(task.getId());
         if (!complete_result.getSuccessStatus()) {
             return complete_result;
         }
@@ -98,5 +99,15 @@ std::vector<TaskDTO> TaskService::getSubTasks(TaskID id) {
 
 std::vector<TaskDTO> TaskService::getSubTasksRecursive(TaskID id) {
     return model_holder_->GetModel().getSubTasksRecursive(id);
+}
+
+RequestResult TaskService::saveToFile(const std::string &filepath) {
+    bool saved = model_holder_->SaveModelToFile(filepath);
+    return saved ? RequestResult::success() : RequestResult(false, "Could not save");
+}
+
+RequestResult TaskService::loadFromFile(const std::string &filepath) {
+    bool loaded = model_holder_->LoadModelFromFile(filepath);
+    return loaded ? RequestResult::success() : RequestResult(false, "Could not load");
 }
 

--- a/src/core/api/TaskService.cpp
+++ b/src/core/api/TaskService.cpp
@@ -17,31 +17,31 @@ TaskCreationResult TaskService::addTask(const TaskDTO &task_data) {
     if (!validate_date(task_data.getDate())) {
         return TaskCreationResult::error("Task date is out of allowed range");
     }
-    return model_->addTask(task_data);
+    return model_holder_->GetModel().addTask(task_data);
 }
 
 TaskCreationResult TaskService::addSubTask(TaskID parent, const TaskDTO &task_data) {
     if (!validate_date(task_data.getDate())) {
         return TaskCreationResult::error("Task date is out of allowed range");
     }
-    return model_->addSubTask(parent, task_data);
+    return model_holder_->GetModel().addSubTask(parent, task_data);
 }
 
 TaskModificationResult
 TaskService::deleteTask(TaskID id) {
-    return model_->dropTask(id);
+    return model_holder_->GetModel().dropTask(id);
 }
 
 TaskModificationResult
 TaskService::postponeTask(TaskID id, BoostDate date_postpone) {
-    std::optional<TaskDTO> is_old_task = model_->getTaskData(id);
+    std::optional<TaskDTO> is_old_task = model_holder_->GetModel().getTaskData(id);
     if (!is_old_task) {
         return TaskModificationResult::taskNotFound();
     }
     TaskDTO old_task = is_old_task.value();
 
     return
-    model_->setTaskData(
+    model_holder_->GetModel().setTaskData(
             id,
             TaskDTO::create(
                     id,
@@ -54,21 +54,21 @@ TaskService::postponeTask(TaskID id, BoostDate date_postpone) {
 }
 
 std::vector<TaskDTO> TaskService::getAllWithLabel(const std::string &label) {
-    return model_->getWithLabel(label);
+    return model_holder_->GetModel().getWithLabel(label);
 }
 
 
 std::optional<TaskDTO> TaskService::getTaskByID(TaskID id) {
-    return model_->getTaskData(id);
+    return model_holder_->GetModel().getTaskData(id);
 }
 
 RequestResult TaskService::complete(TaskID id) {
-    auto root_complete_result = model_->setCompleted(id);
+    auto root_complete_result = model_holder_->GetModel().setCompleted(id);
     if (!root_complete_result.getSuccessStatus()) {
         return root_complete_result;
     }
-    for (const auto& task : model_->getSubTasksRecursive(id)) {
-        auto complete_result = model_->setCompleted(task.getId());
+    for (const auto& task : model_holder_->GetModel().getSubTasksRecursive(id)) {
+        auto complete_result = model_holder_->GetModel().setCompleted(task.getId());
         if (!complete_result.getSuccessStatus()) {
             return complete_result;
         }
@@ -78,25 +78,25 @@ RequestResult TaskService::complete(TaskID id) {
 
 std::vector<TaskDTO> TaskService::getToday() {
     using namespace boost::gregorian;
-    return model_->getToDate(day_clock::local_day());
+    return model_holder_->GetModel().getToDate(day_clock::local_day());
 }
 
 std::vector<TaskDTO> TaskService::getThisWeek() {
     using namespace boost::gregorian;
-    return model_->getToDate(day_clock::local_day() + days(6));
+    return model_holder_->GetModel().getToDate(day_clock::local_day() + days(6));
 }
 
 std::vector<TaskDTO> TaskService::getAllTasks() {
     using namespace boost::gregorian;
-    return model_->getToDate(service::max_date);
+    return model_holder_->GetModel().getToDate(service::max_date);
 }
 
 std::vector<TaskDTO> TaskService::getSubTasks(TaskID id) {
-    return model_->getSubTasks(id);
+    return model_holder_->GetModel().getSubTasks(id);
 }
 
 
 std::vector<TaskDTO> TaskService::getSubTasksRecursive(TaskID id) {
-    return model_->getSubTasksRecursive(id);
+    return model_holder_->GetModel().getSubTasksRecursive(id);
 }
 

--- a/src/core/api/TaskService.h
+++ b/src/core/api/TaskService.h
@@ -4,7 +4,7 @@
 
 #ifndef EVAL_TASKSERVICE_H
 #define EVAL_TASKSERVICE_H
-#include "core/memory_model/api/TaskModelInterface.h"
+#include "core/ModelHolderInterface.h"
 #include "TaskServiceInterface.h"
 #include <unordered_map>
 #include <algorithm>
@@ -19,9 +19,9 @@
 class TaskService : public TaskServiceInterface {
 
 public:
-    explicit TaskService(std::unique_ptr<TaskModelInterface> model)
+    explicit TaskService(std::unique_ptr<ModelHolderInterface> model_holder)
     :
-    model_(std::move(model))
+    model_holder_(std::move(model_holder))
     {}
 
 public:
@@ -44,7 +44,7 @@ public:
     ~TaskService() override =                               default;
 
 private:
-    std::unique_ptr<TaskModelInterface>                     model_;
+    std::unique_ptr<ModelHolderInterface>                   model_holder_;
 };
 
 

--- a/src/core/api/TaskService.h
+++ b/src/core/api/TaskService.h
@@ -41,6 +41,10 @@ public:
     RequestResult                                           complete(TaskID id) override;
 
 public:
+    RequestResult                                           saveToFile(const std::string& filepath) override;
+    RequestResult                                           loadFromFile(const std::string& filepath) override;
+
+public:
     ~TaskService() override =                               default;
 
 private:

--- a/src/core/api/TaskServiceInterface.h
+++ b/src/core/api/TaskServiceInterface.h
@@ -110,6 +110,22 @@ public:
      * @return object info about success or possible error occurred
      */
     virtual RequestResult                                           complete(TaskID id) = 0;
+    /*
+     * Save program state to file
+     *
+     * @param filepath
+     *
+     * @return object containing info about success about error
+     */
+    virtual RequestResult                                           saveToFile(const std::string& filepath) = 0;
+    /*
+     * Load program state from file
+     *
+     * @param filepath
+     *
+     * @return object containing info about success about error
+     */
+    virtual RequestResult                                           loadFromFile(const std::string& filepath) = 0;
 
 public:
     virtual ~TaskServiceInterface() =                               default;

--- a/src/core/memory_model/ModelCreator.cpp
+++ b/src/core/memory_model/ModelCreator.cpp
@@ -1,0 +1,17 @@
+//
+// Created by denis on 02.10.20.
+//
+
+#include "ModelCreator.h"
+
+std::unique_ptr<TaskModelInterface> ModelCreator::CreateModel() {
+    auto storage =      std::make_unique<TaskStorage>();
+    auto view_time =    std::make_unique<DatePriorityView>();
+    auto view_label =   std::make_unique<TagPriorityView>();
+    auto handler =      std::make_unique<LinkManager>(*view_time, *view_label);
+    return std::make_unique<TaskModel>(
+            std::move(storage),
+            std::move(view_time),
+            std::move(view_label),
+            std::move(handler));
+}

--- a/src/core/memory_model/ModelCreator.h
+++ b/src/core/memory_model/ModelCreator.h
@@ -1,0 +1,22 @@
+//
+// Created by denis on 02.10.20.
+//
+
+#ifndef TODOLIST_MODELCREATOR_H
+#define TODOLIST_MODELCREATOR_H
+
+#include "ModelCreatorInterface.h"
+#include "api/TaskModel.h"
+#include "data/TaskStorage.h"
+#include "structure/LinkManager.h"
+#include "view/TagPriorityView.h"
+#include "view/DatePriorityView.h"
+
+class ModelCreator : public ModelCreatorInterface {
+
+public:
+    std::unique_ptr<TaskModelInterface> CreateModel() override;
+};
+
+
+#endif //TODOLIST_MODELCREATOR_H

--- a/src/core/memory_model/ModelCreatorInterface.h
+++ b/src/core/memory_model/ModelCreatorInterface.h
@@ -1,0 +1,18 @@
+//
+// Created by denis on 02.10.20.
+//
+
+#ifndef TODOLIST_MODELCREATORINTERFACE_H
+#define TODOLIST_MODELCREATORINTERFACE_H
+
+#include "api/TaskModelInterface.h"
+
+class ModelCreatorInterface {
+
+public:
+    virtual std::unique_ptr<TaskModelInterface> CreateModel() = 0;
+};
+
+
+
+#endif //TODOLIST_MODELCREATORINTERFACE_H

--- a/src/core/memory_model/ModelCreatorInterface.h
+++ b/src/core/memory_model/ModelCreatorInterface.h
@@ -11,6 +11,7 @@ class ModelCreatorInterface {
 
 public:
     virtual std::unique_ptr<TaskModelInterface> CreateModel() = 0;
+    virtual ~ModelCreatorInterface() = default;
 };
 
 

--- a/tests/core/TestModelHolder.cpp
+++ b/tests/core/TestModelHolder.cpp
@@ -1,0 +1,91 @@
+//
+// Created by denis on 04.10.20.
+//
+
+#include "mocks/CoreMocks.h"
+#include "mocks/MockModelPersister.h"
+#include "mocks/MockStreamOwner.h"
+#include "core/ModelHolder.h"
+
+using ::testing::Ref;
+using ::testing::ReturnRef;
+using ::testing::ByMove;
+
+class ModelHolderTest : public ::testing::Test {
+
+};
+
+
+TEST_F(ModelHolderTest, TestSaveSuccessfull) {
+    auto mm =  std::make_unique<MockModel>();
+    TaskModelInterface *mmget = mm.get();
+    auto mmc = std::make_unique<MockModelCreator>();
+    auto mmp = std::make_unique<MockModelPersister>();
+    MockStreamOwner mso;
+    EXPECT_CALL(mso, SetStream).Times(1);
+    EXPECT_CALL(*mmc, CreateModel).WillOnce(Return(ByMove(std::move(mm))));
+    EXPECT_CALL(*mmp, Save(Truly(
+            [mmget] (const TaskModelInterface& mip) {
+                return &mip == mmget;
+            })))
+            .WillOnce(Return(true));
+    ModelHolder mh(std::move(mmc), std::move(mmp), mso);
+    ASSERT_TRUE(mh.SaveModelToFile("abacabadabacaba"));
+}
+
+TEST_F(ModelHolderTest, TestSaveFail) {
+    auto mm =  std::make_unique<MockModel>();
+    TaskModelInterface *mmget = mm.get();
+    auto mmc = std::make_unique<MockModelCreator>();
+    auto mmp = std::make_unique<MockModelPersister>();
+    MockStreamOwner mso;
+    EXPECT_CALL(mso, SetStream).Times(1);
+    EXPECT_CALL(*mmc, CreateModel).WillOnce(Return(ByMove(std::move(mm))));
+    EXPECT_CALL(*mmp, Save(Truly(
+            [mmget] (const TaskModelInterface& mip) {
+                return &mip == mmget;
+            })))
+            .WillOnce(Return(false));
+    ModelHolder mh(std::move(mmc), std::move(mmp), mso);
+    ASSERT_FALSE(mh.SaveModelToFile("abacabadabacaba"));
+}
+
+TEST_F(ModelHolderTest, TestLoadSuccessfull) {
+    auto mm =  std::make_unique<MockModel>();
+    auto mm0 =  std::make_unique<MockModel>();
+    TaskModelInterface *mmget = mm.get();
+    auto mmc = std::make_unique<MockModelCreator>();
+    auto mmp = std::make_unique<MockModelPersister>();
+    MockStreamOwner mso;
+    EXPECT_CALL(mso, SetStream).Times(1);
+    EXPECT_CALL(*mmc, CreateModel)
+        .WillOnce(Return(ByMove(std::move(mm0))))
+        .WillOnce(Return(ByMove(std::move(mm))));
+    EXPECT_CALL(*mmp, Load(Truly(
+            [mmget] (TaskModelInterface& mip) {
+                return &mip == mmget;
+            })))
+            .WillOnce(Return(true));
+    ModelHolder mh(std::move(mmc), std::move(mmp), mso);
+    ASSERT_TRUE(mh.LoadModelFromFile("abacabadabacaba"));
+}
+
+TEST_F(ModelHolderTest, TestLoadFail) {
+    auto mm =  std::make_unique<MockModel>();
+    auto mm0 =  std::make_unique<MockModel>();
+    TaskModelInterface *mmget = mm.get();
+    auto mmc = std::make_unique<MockModelCreator>();
+    auto mmp = std::make_unique<MockModelPersister>();
+    MockStreamOwner mso;
+    EXPECT_CALL(mso, SetStream).Times(1);
+    EXPECT_CALL(*mmc, CreateModel)
+            .WillOnce(Return(ByMove(std::move(mm0))))
+            .WillOnce(Return(ByMove(std::move(mm))));
+    EXPECT_CALL(*mmp, Load(Truly(
+            [mmget] (TaskModelInterface& mip) {
+                return &mip == mmget;
+            })))
+            .WillOnce(Return(false));
+    ModelHolder mh(std::move(mmc), std::move(mmp), mso);
+    ASSERT_FALSE(mh.LoadModelFromFile("abacabadabacaba"));
+}

--- a/tests/core/TestTaskService.cpp
+++ b/tests/core/TestTaskService.cpp
@@ -185,3 +185,43 @@ TEST_F(TaskServiceTest, TestGetThisWeek) {
     TaskService ts = TaskService(std::move(mmh));
     ts.getThisWeek();
 }
+
+TEST_F(TaskServiceTest, TestLoadFromFile) {
+    auto mm = std::make_unique<MockModel>();
+    auto mmh = std::make_unique<MockModelHolder>();
+    EXPECT_CALL(*mmh, GetModel).WillRepeatedly(ReturnRef(*mm));
+    std::string filepath = "abacabadabacaba";
+    EXPECT_CALL(*mmh, LoadModelFromFile(filepath)).Times(1).WillOnce(Return(true));;
+    TaskService ts = TaskService(std::move(mmh));
+    EXPECT_TRUE(ts.loadFromFile(filepath).getSuccessStatus());
+}
+
+TEST_F(TaskServiceTest, TestLoadFromFileReturn) {
+    auto mm = std::make_unique<MockModel>();
+    auto mmh = std::make_unique<MockModelHolder>();
+    EXPECT_CALL(*mmh, GetModel).WillRepeatedly(ReturnRef(*mm));
+    std::string filepath = "abacabadabacaba";
+    EXPECT_CALL(*mmh, LoadModelFromFile(filepath)).Times(1).WillOnce(Return(true));
+    TaskService ts = TaskService(std::move(mmh));
+    EXPECT_TRUE(ts.loadFromFile(filepath).getSuccessStatus());
+}
+
+TEST_F(TaskServiceTest, TestSaveToFileReturnsErrorOnFail) {
+    auto mm = std::make_unique<MockModel>();
+    auto mmh = std::make_unique<MockModelHolder>();
+    EXPECT_CALL(*mmh, GetModel).WillRepeatedly(ReturnRef(*mm));
+    std::string filepath = "abacabadabacaba";
+    EXPECT_CALL(*mmh, SaveModelToFile(filepath)).Times(1).WillOnce(Return(false));
+    TaskService ts = TaskService(std::move(mmh));
+    EXPECT_FALSE(ts.saveToFile(filepath).getSuccessStatus());
+}
+
+TEST_F(TaskServiceTest, TestLoadFromFileReturnsErrorOnFail) {
+    auto mm = std::make_unique<MockModel>();
+    auto mmh = std::make_unique<MockModelHolder>();
+    EXPECT_CALL(*mmh, GetModel).WillRepeatedly(ReturnRef(*mm));
+    std::string filepath = "abacabadabacaba";
+    EXPECT_CALL(*mmh, SaveModelToFile(filepath)).Times(1).WillOnce(Return(false));
+    TaskService ts = TaskService(std::move(mmh));
+    EXPECT_FALSE(ts.saveToFile(filepath).getSuccessStatus());
+}

--- a/tests/core/TestTaskService.cpp
+++ b/tests/core/TestTaskService.cpp
@@ -8,9 +8,11 @@
 #include "core/utils/data_transfer/TaskDTOConverter.h"
 #include "core/utils/task_io/ConsoleTaskIO.h"
 #include "mocks/CoreMocks.h"
+#include "mocks/MockModelHolder.h"
 
 using ::testing::AnyNumber;
 using ::testing::Return;
+using ::testing::ReturnRef;
 using ::testing::Action;
 using ::testing::NiceMock;
 using ::testing::_;
@@ -38,6 +40,8 @@ auto dto_equal(const TaskDTO& rhs) {
 TEST_F(TaskServiceTest, TestAllSubtasksComplete) {
     TaskID root(0);
     auto mm = std::make_unique<MockModel>();
+    auto mmh = std::make_unique<MockModelHolder>();
+    EXPECT_CALL(*mmh, GetModel).WillRepeatedly(ReturnRef(*mm));
     EXPECT_CALL(*mm, getSubTasksRecursive(root)).WillOnce(Return(
             std::vector<TaskDTO> {
         TaskDTO::create(TaskID(1), "", TaskPriority::FIRST, "", BoostDate()),
@@ -50,13 +54,15 @@ TEST_F(TaskServiceTest, TestAllSubtasksComplete) {
     EXPECT_CALL(*mm, setCompleted(TaskID(2))).WillOnce(Return(TaskModificationResult::success()));
     EXPECT_CALL(*mm, setCompleted(TaskID(3))).WillOnce(Return(TaskModificationResult::success()));
     EXPECT_CALL(*mm, setCompleted(TaskID(4))).WillOnce(Return(TaskModificationResult::success()));
-    TaskService ts = TaskService(std::move(mm));
+    TaskService ts = TaskService(std::move(mmh));
     ts.complete(root);
 }
 
 TEST_F(TaskServiceTest, TestTaskWithDateBiggerThenMaxNotAdded) {
     auto mm = std::make_unique<MockModel>();
-    TaskService ts = TaskService(std::move(mm));
+    auto mmh = std::make_unique<MockModelHolder>();
+    EXPECT_CALL(*mmh, GetModel).WillRepeatedly(ReturnRef(*mm));
+    TaskService ts = TaskService(std::move(mmh));
     ASSERT_FALSE(ts.addTask(
             TaskDTO::create("nm",
                     TaskPriority::FIRST,
@@ -67,7 +73,9 @@ TEST_F(TaskServiceTest, TestTaskWithDateBiggerThenMaxNotAdded) {
 
 TEST_F(TaskServiceTest, TestTaskWithDateBeforeTodayNotAdded) {
     auto mm = std::make_unique<MockModel>();
-    TaskService ts = TaskService(std::move(mm));
+    auto mmh = std::make_unique<MockModelHolder>();
+    EXPECT_CALL(*mmh, GetModel).WillRepeatedly(ReturnRef(*mm));
+    TaskService ts = TaskService(std::move(mmh));
     ASSERT_FALSE(ts.addTask(
                     TaskDTO::create("nm",
                                     TaskPriority::FIRST,
@@ -79,32 +87,40 @@ TEST_F(TaskServiceTest, TestTaskWithDateBeforeTodayNotAdded) {
 TEST_F(TaskServiceTest, TestGetTaskData) {
     TaskDTO dto = TaskDTO::create("", TaskPriority::NONE, "", BoostDate());
     auto mm = std::make_unique<MockModel>();
+    auto mmh = std::make_unique<MockModelHolder>();
+    EXPECT_CALL(*mmh, GetModel).WillRepeatedly(ReturnRef(*mm));
     EXPECT_CALL(*mm, getTaskData(dto.getId())).WillOnce(Return(dto));
-    TaskService ts = TaskService(std::move(mm));
+    TaskService ts = TaskService(std::move(mmh));
     EXPECT_TRUE(ts.getTaskByID(dto.getId()));
 }
 
 TEST_F(TaskServiceTest, TestAddSubTaskReturnsErrorIfNoSuchTask) {
     TaskID to_par(1);
     auto mm = std::make_unique<MockModel>();
+    auto mmh = std::make_unique<MockModelHolder>();
+    EXPECT_CALL(*mmh, GetModel).WillRepeatedly(ReturnRef(*mm));
     EXPECT_CALL(*mm, addSubTask(to_par, _)).WillOnce(Return(TaskCreationResult::taskNotFound()));
-    TaskService ts = TaskService(std::move(mm));
+    TaskService ts = TaskService(std::move(mmh));
     EXPECT_FALSE(ts.addSubTask(to_par, TaskDTO::create("", TaskPriority::NONE, "", day_clock::local_day())).getSuccessStatus());
 }
 
 TEST_F(TaskServiceTest, TestDeleteTaskReturnsErrorIfNoSuchTask) {
     TaskID to_drop(1);
     auto mm = std::make_unique<MockModel>();
+    auto mmh = std::make_unique<MockModelHolder>();
+    EXPECT_CALL(*mmh, GetModel).WillRepeatedly(ReturnRef(*mm));
     EXPECT_CALL(*mm, dropTask(to_drop)).WillOnce(Return(TaskModificationResult::taskNotFound()));
-    TaskService ts = TaskService(std::move(mm));
+    TaskService ts = TaskService(std::move(mmh));
     EXPECT_FALSE(ts.deleteTask(to_drop).getSuccessStatus());
 }
 
 TEST_F(TaskServiceTest, TestPostponeTaskReturnsErrorIfNoSuchTask) {
     TaskID to_postpone(1);
     auto mm = std::make_unique<MockModel>();
+    auto mmh = std::make_unique<MockModelHolder>();
+    EXPECT_CALL(*mmh, GetModel).WillRepeatedly(ReturnRef(*mm));
     EXPECT_CALL(*mm, getTaskData(to_postpone)).WillOnce(Return(std::nullopt));
-    TaskService ts = TaskService(std::move(mm));
+    TaskService ts = TaskService(std::move(mmh));
     EXPECT_FALSE(ts.postponeTask(to_postpone, BoostDate()).getSuccessStatus());
 }
 
@@ -114,10 +130,12 @@ TEST_F(TaskServiceTest, TestPostponeTask) {
     auto new_task =
     TaskDTO::create(TaskID(5), "name", TaskPriority::SECOND, "label", day_clock::local_day() + days(10), true);
     auto mm = std::make_unique<MockModel>();
+    auto mmh = std::make_unique<MockModelHolder>();
+    EXPECT_CALL(*mmh, GetModel).WillRepeatedly(ReturnRef(*mm));
     EXPECT_CALL(*mm, getTaskData(old_task.getId())).WillOnce(Return(old_task));
     EXPECT_CALL(*mm, setTaskData(old_task.getId(), Truly(dto_equal(new_task))))
     .WillOnce(Return(TaskModificationResult::success()));
-    TaskService ts = TaskService(std::move(mm));
+    TaskService ts = TaskService(std::move(mmh));
     ASSERT_TRUE(ts.postponeTask(old_task.getId(), day_clock::local_day() + days(10))
     .getSuccessStatus());
 }
@@ -125,35 +143,45 @@ TEST_F(TaskServiceTest, TestPostponeTask) {
 TEST_F(TaskServiceTest, TestGetSubtasks) {
     TaskID root(9);
     auto mm = std::make_unique<MockModel>();
+    auto mmh = std::make_unique<MockModelHolder>();
+    EXPECT_CALL(*mmh, GetModel).WillRepeatedly(ReturnRef(*mm));
     EXPECT_CALL(*mm, getSubTasks(root)).Times(1);
-    TaskService ts = TaskService(std::move(mm));
+    TaskService ts = TaskService(std::move(mmh));
     ts.getSubTasks(root);
 }
 
 TEST_F(TaskServiceTest, TestGetAllTasks) {
     auto mm = std::make_unique<MockModel>();
+    auto mmh = std::make_unique<MockModelHolder>();
+    EXPECT_CALL(*mmh, GetModel).WillRepeatedly(ReturnRef(*mm));
     EXPECT_CALL(*mm, getToDate(service::max_date)).Times(1);
-    TaskService ts = TaskService(std::move(mm));
+    TaskService ts = TaskService(std::move(mmh));
     ts.getAllTasks();
 }
 
 TEST_F(TaskServiceTest, TestGetByLabel) {
     auto mm = std::make_unique<MockModel>();
+    auto mmh = std::make_unique<MockModelHolder>();
+    EXPECT_CALL(*mmh, GetModel).WillRepeatedly(ReturnRef(*mm));
     EXPECT_CALL(*mm, getWithLabel("label")).Times(1);
-    TaskService ts = TaskService(std::move(mm));
+    TaskService ts = TaskService(std::move(mmh));
     ts.getAllWithLabel("label");
 }
 
 TEST_F(TaskServiceTest, TestGetToday) {
     auto mm = std::make_unique<MockModel>();
+    auto mmh = std::make_unique<MockModelHolder>();
+    EXPECT_CALL(*mmh, GetModel).WillRepeatedly(ReturnRef(*mm));
     EXPECT_CALL(*mm, getToDate(day_clock::local_day())).Times(1);
-    TaskService ts = TaskService(std::move(mm));
+    TaskService ts = TaskService(std::move(mmh));
     ts.getToday();
 }
 
 TEST_F(TaskServiceTest, TestGetThisWeek) {
     auto mm = std::make_unique<MockModel>();
+    auto mmh = std::make_unique<MockModelHolder>();
+    EXPECT_CALL(*mmh, GetModel).WillRepeatedly(ReturnRef(*mm));
     EXPECT_CALL(*mm, getToDate(day_clock::local_day() + days(6))).Times(1);
-    TaskService ts = TaskService(std::move(mm));
+    TaskService ts = TaskService(std::move(mmh));
     ts.getThisWeek();
 }

--- a/tests/mocks/CoreMocks.h
+++ b/tests/mocks/CoreMocks.h
@@ -11,6 +11,7 @@
 #include "core/memory_model/structure/LinkManagerInterface.h"
 #include "core/memory_model/view/PriorityViewInterface.h"
 #include "core/memory_model/api/TaskModelInterface.h"
+#include "core/memory_model/ModelCreatorInterface.h"
 
 using ::testing::AnyNumber;
 using ::testing::Return;
@@ -66,6 +67,12 @@ public:
     MOCK_METHOD(std::vector<TaskDTO>,   getAllTasks, (), (const, override));
     MOCK_METHOD(std::optional<TaskDTO>, getParentTask, (TaskID id), (const, override));
 
+};
+
+class MockModelCreator : public ModelCreatorInterface {
+
+public:
+    MOCK_METHOD(std::unique_ptr<TaskModelInterface>, CreateModel, (), (override));
 };
 
 #endif //TODOLIST_MOCKS_H

--- a/tests/mocks/MockModelHolder.h
+++ b/tests/mocks/MockModelHolder.h
@@ -1,0 +1,21 @@
+//
+// Created by denis on 04.10.20.
+//
+
+#ifndef TODOLIST_MOCKMODELHOLDER_H
+#define TODOLIST_MOCKMODELHOLDER_H
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include "core/ModelHolderInterface.h"
+
+class MockModelHolder : public ModelHolderInterface {
+
+public:
+    MOCK_METHOD(TaskModelInterface&, GetModel,(), (override));
+    MOCK_METHOD(bool               , LoadModelFromFile, (const std::string& filepath), (override));
+    MOCK_METHOD(bool               , SaveModelToFile, (const std::string& filepath), (override));
+};
+
+
+#endif //TODOLIST_MOCKMODELHOLDER_H

--- a/tests/mocks/MockService.h
+++ b/tests/mocks/MockService.h
@@ -27,6 +27,8 @@ public:
     MOCK_METHOD(RequestResult         , complete, (TaskID), (override));
     MOCK_METHOD(std::vector<TaskDTO>, getSubTasks, (TaskID id), (override));
     MOCK_METHOD(std::vector<TaskDTO>, getSubTasksRecursive, (TaskID id), (override));
+    MOCK_METHOD(RequestResult, saveToFile, (const std::string&), (override));
+    MOCK_METHOD(RequestResult, loadFromFile, (const std::string&), (override));
 };
 
 #endif //TODOLIST_MOCKSERVICE_H

--- a/tests/mocks/MockStreamOwner.h
+++ b/tests/mocks/MockStreamOwner.h
@@ -1,0 +1,20 @@
+//
+// Created by denis on 04.10.20.
+//
+
+#ifndef TODOLIST_MOCKSTREAMOWNER_H
+#define TODOLIST_MOCKSTREAMOWNER_H
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include "core/persistence/StreamOwner.h"
+
+
+class MockStreamOwner : public StreamOwner {
+
+public:
+    MOCK_METHOD(void, SetStream, (std::unique_ptr<std::iostream>), (override));
+};
+
+
+#endif //TODOLIST_MOCKSTREAMOWNER_H


### PR DESCRIPTION
Change TaskService model storage way. Now model is handled by ModelHolder, which has GetModel method.
Add Save/Load feature to TaskService and test.