### PR TITLE
Async saveload

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,7 @@ add_executable(ToDOList src/main.cpp
         ${CORE_SOURCES} ${CORE_HEADERS}
         ${PROTO_SRCS} ${PROTO_HDRS})
 target_link_libraries(ToDOList ${Boost_LIBRARIES})
-target_link_libraries(ToDOList -static ${Protobuf_LIBRARIES})
+target_link_libraries(ToDOList ${Protobuf_LIBRARIES})
 
 # tests #####################################
 include(GoogleTest)


### PR DESCRIPTION
- Fix bug when protobuf crash instantly when using threads in program. It was caused by protobuf static linkage.

- Perform persister calls in separate threads with std::async.