### PR TITLE
Grpc task service implementation.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,7 +148,9 @@ add_executable(TestsExecutable
         ${CLI_SOURCES} ${CLI_HEADERS}
         ${CORE_SOURCES} ${CORE_HEADERS}
         ${TESTS} ${MOCKS}
-        ${PROTO_SRCS} ${PROTO_HDRS})
+        ${PROTO_SRCS} ${PROTO_HDRS}
+        ${ts_proto_srcs}
+        ${ts_grpc_srcs})
 target_link_libraries(TestsExecutable GTest::GTest GTest::Main
         ${GMOCK_LIBRARY} ${GMOCK_MAIN_LIBRARY}
         ${Boost_LIBRARIES}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,13 +3,15 @@ cmake_minimum_required(VERSION 3.15)
 project(ToDOlist)
 include_directories(src)
 include_directories(tests)
-SET(CMAKE_C_FLAGS_DEBUG "-D_DEBUG")
+#SET(CMAKE_C_FLAGS_DEBUG "-D_DEBUG")
+SET(CMAKE_CXX_FLAGS "-fstandalone-debug")
 set(CMAKE_CXX_STANDARD 17)
+
 #set(CMAKE_CXX_STANDARD_REQUIRED ON)
 #set(BUILD_SHARED_LIBS OFF)
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fprofile-instr-generate -fcoverage-mapping")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fprofile-instr-generate -fcoverage-mapping")
+#set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fprofile-instr-generate -fcoverage-mapping")
+#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fprofile-instr-generate -fcoverage-mapping")
 #set(CMAKE_CXX_FLAGS "-D_GLIBCXX_DEBUG")
 
 # boost #####################################################
@@ -28,11 +30,48 @@ find_package(Protobuf REQUIRED)
 include_directories(${Protobuf_INCLUDE_DIRS})
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
-file(GLOB_RECURSE PROTO_SOURCES CONFIGURE_DEPENDS ${CMAKE_SOURCE_DIR}/proto/*.proto )
+file(GLOB_RECURSE PROTO_SOURCES CONFIGURE_DEPENDS ${CMAKE_SOURCE_DIR}/proto/task.proto )
 protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS ${PROTO_SOURCES})
 message("Generated ${PROTO_SRCS} ${PROTO_HDRS}")
 
 SET_SOURCE_FILES_PROPERTIES(${PROTO_SRCS} ${PROTO_HDRS} PROPERTIES GENERATED TRUE)
+
+#gRPC###################################
+
+set(_PROTOBUF_LIBPROTOBUF protobuf::libprotobuf)
+set(_REFLECTION gRPC::grpc++_reflection)
+
+
+# Find gRPC installation
+# Looks for gRPCConfig.cmake file installed by gRPC's cmake installation.
+find_package(gRPC REQUIRED)
+message(STATUS "Using gRPC ${gRPC_VERSION}")
+
+set(_GRPC_GRPCPP gRPC::grpc++)
+find_program(_GRPC_CPP_PLUGIN_EXECUTABLE grpc_cpp_plugin)
+
+##########################################
+
+# Proto file
+get_filename_component(ts_proto "proto/TaskService.proto" ABSOLUTE)
+get_filename_component(ts_proto_path "${ts_proto}" PATH)
+
+set(ts_proto_srcs "${CMAKE_CURRENT_BINARY_DIR}/TaskService.pb.cc")
+set(ts_proto_hdrs "${CMAKE_CURRENT_BINARY_DIR}/TaskService.pb.h")
+set(ts_grpc_srcs "${CMAKE_CURRENT_BINARY_DIR}/TaskService.grpc.pb.cc")
+set(ts_grpc_hdrs "${CMAKE_CURRENT_BINARY_DIR}/TaskService.grpc.pb.h")
+add_custom_command(
+        OUTPUT "${ts_proto_srcs}" "${ts_proto_hdrs}" "${ts_grpc_srcs}" "${ts_grpc_hdrs}"
+        COMMAND protoc
+        ARGS -I "${ts_proto_path}"
+        --grpc_out "${CMAKE_CURRENT_BINARY_DIR}"
+        --cpp_out "${CMAKE_CURRENT_BINARY_DIR}"
+        --plugin=protoc-gen-grpc="${_GRPC_CPP_PLUGIN_EXECUTABLE}"
+        ${ts_proto}
+        DEPENDS ${ts_proto})
+
+
+include_directories("${CMAKE_CURRENT_BINARY_DIR}")
 
 
 
@@ -60,9 +99,41 @@ file( GLOB_RECURSE CORE_SOURCES src/core/*.cpp)
 add_executable(ToDOList src/main.cpp
         ${CLI_SOURCES} ${CLI_HEADERS}
         ${CORE_SOURCES} ${CORE_HEADERS}
-        ${PROTO_SRCS} ${PROTO_HDRS})
-target_link_libraries(ToDOList ${Boost_LIBRARIES})
-target_link_libraries(ToDOList ${Protobuf_LIBRARIES})
+        ${PROTO_SRCS} ${PROTO_HDRS}
+        ${ts_proto_srcs} ${ts_proto_hdrs}
+        ${ts_grpc_srcs} ${ts_grpc_hdrs})
+target_link_libraries(ToDOList ${Boost_LIBRARIES} ${_REFLECTION}
+        ${_GRPC_GRPCPP}
+        ${_PROTOBUF_LIBPROTOBUF})
+
+add_executable(Server src/Server.cpp
+        src/core/api/GrpcTaskServiceImpl.h src/core/api/GrpcTaskServiceImpl.cpp
+        ${Boost_LIBRARIES}
+        ${CLI_SOURCES} ${CLI_HEADERS}
+        ${CORE_SOURCES} ${CORE_HEADERS}
+        ${PROTO_SRCS} ${PROTO_HDRS}
+        ${ts_proto_srcs}
+        ${ts_grpc_srcs})
+target_link_libraries(Server
+        ${Boost_LIBRARIES}
+        ${_REFLECTION}
+        ${_GRPC_GRPCPP}
+        ${_PROTOBUF_LIBPROTOBUF})
+
+add_executable(Client src/Client.cpp
+        src/core/api/GrpcTaskServiceImpl.h src/core/api/GrpcTaskServiceImpl.cpp
+        ${CLI_SOURCES} ${CLI_HEADERS}
+        ${CORE_SOURCES} ${CORE_HEADERS}
+        ${PROTO_SRCS} ${PROTO_HDRS}
+        ${ts_proto_srcs}
+        ${ts_grpc_srcs})
+target_link_libraries(Client
+        ${Boost_LIBRARIES}
+        ${_REFLECTION}
+        ${_GRPC_GRPCPP}
+        ${_PROTOBUF_LIBPROTOBUF})
+
+#target_link_libraries(ToDOList ${Protobuf_LIBRARIES})
 
 # tests #####################################
 include(GoogleTest)
@@ -80,8 +151,10 @@ add_executable(TestsExecutable
         ${PROTO_SRCS} ${PROTO_HDRS})
 target_link_libraries(TestsExecutable GTest::GTest GTest::Main
         ${GMOCK_LIBRARY} ${GMOCK_MAIN_LIBRARY}
-        ${Boost_LIBRARIES})
-target_link_libraries(TestsExecutable ${Protobuf_LIBRARIES})
+        ${Boost_LIBRARIES}
+        ${_REFLECTION}
+        ${_GRPC_GRPCPP}
+        ${_PROTOBUF_LIBPROTOBUF})
 
 gtest_discover_tests(TestsExecutable)
 

--- a/proto/TaskService.proto
+++ b/proto/TaskService.proto
@@ -8,6 +8,8 @@ service GrpcTaskService {
   rpc AddSubTask (AddSubTaskRequest) returns (AddTaskResponse) {}
 }
 
+// Just an wrapper serving as optional
+// response.has_task() == false is interpreted as nullopt
 message GetTaskByIDResponse {
   TaskData task = 1;
 }

--- a/proto/TaskService.proto
+++ b/proto/TaskService.proto
@@ -3,9 +3,20 @@ syntax = "proto3";
 import "task.proto";
 
 service GrpcTaskService {
-  rpc GetTaskByID (TaskIdMessage) returns (GetTaskByIDResponse) {}
-  rpc AddTask (TaskData) returns (AddTaskResponse) {}
-  rpc AddSubTask (AddSubTaskRequest) returns (AddTaskResponse) {}
+  rpc GetTaskByID           (TaskIdMessage)         returns (GetTaskByIDResponse) {}
+  rpc AddTask               (TaskData)              returns (AddTaskResponse) {}
+  rpc AddSubTask            (AddSubTaskRequest)     returns (AddTaskResponse) {}
+  rpc GetAllWithLabel       (StringRequest)         returns (TaskDTOList) {}
+  rpc GetToday              (EmptyRequest)          returns (TaskDTOList) {}
+  rpc GetThisWeek           (EmptyRequest)          returns (TaskDTOList) {}
+  rpc GetAllTasks           (EmptyRequest)          returns (TaskDTOList) {}
+  rpc GetSubTasks           (TaskIdMessage)         returns (TaskDTOList) {}
+  rpc GetSubTasksRecursive  (TaskIdMessage)         returns (TaskDTOList) {}
+  rpc DeleteTask            (TaskIdMessage)         returns (DefaultResponse) {}
+  rpc PostponeTask          (TaskIdMessage)         returns (DefaultResponse) {}
+  rpc CompleteTask          (TaskIdMessage)         returns (DefaultResponse) {}
+  rpc SaveToFile            (StringRequest)         returns (DefaultResponse) {}
+  rpc LoadFromFile          (StringRequest)         returns (DefaultResponse) {}
 }
 
 // Just an wrapper serving as optional
@@ -23,4 +34,26 @@ message AddTaskResponse {
   bool success = 1;
   TaskIdMessage created_id = 2;
   string error_msg = 3;
+}
+
+message GrpcTaskDTO {
+  TaskIdMessage id = 1;
+  TaskData task = 2;
+}
+
+message TaskDTOList {
+  repeated GrpcTaskDTO tasks = 1;
+}
+
+message StringRequest {
+  string str = 1;
+}
+
+message EmptyRequest {
+
+}
+
+message DefaultResponse {
+  bool success = 1;
+  string error_msg = 2;
 }

--- a/proto/TaskService.proto
+++ b/proto/TaskService.proto
@@ -1,0 +1,24 @@
+syntax = "proto3";
+
+import "task.proto";
+
+service GrpcTaskService {
+  rpc GetTaskByID (TaskIdMessage) returns (GetTaskByIDResponse) {}
+  rpc AddTask (TaskData) returns (AddTaskResponse) {}
+  rpc AddSubTask (AddSubTaskRequest) returns (AddTaskResponse) {}
+}
+
+message GetTaskByIDResponse {
+  TaskData task = 1;
+}
+
+message AddSubTaskRequest {
+  TaskIdMessage parent = 1;
+  TaskData task = 2;
+}
+
+message AddTaskResponse {
+  bool success = 1;
+  TaskIdMessage created_id = 2;
+  string error_msg = 3;
+}

--- a/proto/TaskService.proto
+++ b/proto/TaskService.proto
@@ -1,6 +1,7 @@
 syntax = "proto3";
 
 import "task.proto";
+import "google/protobuf/timestamp.proto";
 
 service GrpcTaskService {
   rpc GetTaskByID           (TaskIdMessage)         returns (GetTaskByIDResponse) {}
@@ -13,7 +14,7 @@ service GrpcTaskService {
   rpc GetSubTasks           (TaskIdMessage)         returns (TaskDTOList) {}
   rpc GetSubTasksRecursive  (TaskIdMessage)         returns (TaskDTOList) {}
   rpc DeleteTask            (TaskIdMessage)         returns (DefaultResponse) {}
-  rpc PostponeTask          (TaskIdMessage)         returns (DefaultResponse) {}
+  rpc PostponeTask          (PostponeRequest)       returns (DefaultResponse) {}
   rpc CompleteTask          (TaskIdMessage)         returns (DefaultResponse) {}
   rpc SaveToFile            (StringRequest)         returns (DefaultResponse) {}
   rpc LoadFromFile          (StringRequest)         returns (DefaultResponse) {}
@@ -44,6 +45,12 @@ message GrpcTaskDTO {
 message TaskDTOList {
   repeated GrpcTaskDTO tasks = 1;
 }
+
+message PostponeRequest {
+  TaskIdMessage id = 1;
+  google.protobuf.Timestamp date_postpone = 2;
+}
+
 
 message StringRequest {
   string str = 1;

--- a/proto/TaskService.proto
+++ b/proto/TaskService.proto
@@ -7,7 +7,7 @@ service GrpcTaskService {
   rpc GetTaskByID           (TaskIdMessage)         returns (GetTaskByIDResponse) {}
   rpc AddTask               (TaskData)              returns (AddTaskResponse) {}
   rpc AddSubTask            (AddSubTaskRequest)     returns (AddTaskResponse) {}
-  rpc GetAllWithLabel       (StringRequest)         returns (TaskDTOList) {}
+  rpc GetAllWithLabel       (StringMessage)         returns (TaskDTOList) {}
   rpc GetToday              (EmptyRequest)          returns (TaskDTOList) {}
   rpc GetThisWeek           (EmptyRequest)          returns (TaskDTOList) {}
   rpc GetAllTasks           (EmptyRequest)          returns (TaskDTOList) {}
@@ -16,8 +16,8 @@ service GrpcTaskService {
   rpc DeleteTask            (TaskIdMessage)         returns (DefaultResponse) {}
   rpc PostponeTask          (PostponeRequest)       returns (DefaultResponse) {}
   rpc CompleteTask          (TaskIdMessage)         returns (DefaultResponse) {}
-  rpc SaveToFile            (StringRequest)         returns (DefaultResponse) {}
-  rpc LoadFromFile          (StringRequest)         returns (DefaultResponse) {}
+  rpc SaveToFile            (StringMessage)         returns (DefaultResponse) {}
+  rpc LoadFromFile          (StringMessage)         returns (DefaultResponse) {}
 }
 
 // Just an wrapper serving as optional
@@ -52,7 +52,7 @@ message PostponeRequest {
 }
 
 
-message StringRequest {
+message StringMessage {
   string str = 1;
 }
 

--- a/proto/task.proto
+++ b/proto/task.proto
@@ -1,4 +1,5 @@
 syntax = "proto3";
+
 import "google/protobuf/timestamp.proto";
 
 message TaskData {
@@ -14,6 +15,10 @@ message TaskData {
   google.protobuf.Timestamp  date        = 4;
   bool                       completed   = 5;
 
+}
+
+message TaskIdMessage {
+  uint32 id = 1;
 }
 
 message TaskMessage {

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -1,0 +1,126 @@
+//
+// Created by denis on 22.10.20.
+//
+
+#include <iostream>
+#include <memory>
+#include <string>
+
+
+#include <grpcpp/grpcpp.h>
+
+
+using grpc::Channel;
+using grpc::ClientContext;
+using grpc::Status;
+
+#include "core/persistence/ProtoConvert.h"
+#include "TaskService.grpc.pb.h"
+
+class ToDOListClient {
+
+public:
+    explicit ToDOListClient(const std::shared_ptr<Channel>& channel)
+            : stub_(GrpcTaskService::NewStub(channel)), status(Status::OK) {}
+
+    // Assembles the client's payload, sends it and presents the response back
+    // from the server.
+    std::optional<TaskData> GetTaskByID(uint32_t id) {
+        // Data we are sending to the server.
+        TaskIdMessage request;
+        request.set_id(id);
+
+        // Container for the data we expect from the server.
+        GetTaskByIDResponse reply;
+        // Context for the client. It could be used to convey extra information to
+        // the server and/or tweak certain RPC behaviors.
+        ClientContext context;
+
+        // The actual RPC.
+        status = stub_->GetTaskByID(&context, request, &reply);
+
+        // Act upon its status.
+        if (status.ok()) {
+            if (reply.has_task()) {
+                return reply.task();
+            } else {
+                return std::nullopt;
+            }
+        } else {
+            std::cout << status.error_code() << ": " << status.error_message()
+                      << std::endl;
+            return std::nullopt;
+        }
+    }
+    AddTaskResponse AddTask(const TaskData& task) {
+        // Data we are sending to the server.
+        const TaskData request = task;
+
+        // Container for the data we expect from the server.
+        AddTaskResponse reply;
+        // Context for the client. It could be used to convey extra information to
+        // the server and/or tweak certain RPC behaviors.
+        ClientContext context;
+
+        // The actual RPC.
+        status = stub_->AddTask(&context, request, &reply);
+
+        // Act upon its status.
+        if (status.ok()) {
+            return reply;
+        } else {
+            std::cout << status.error_code() << ": " << status.error_message()
+                      << std::endl;
+        }
+        return reply;
+    }
+    Status status;
+private:
+
+    std::unique_ptr<GrpcTaskService::Stub> stub_;
+};
+
+
+int main() {
+    std::string server_address("0.0.0.0:50051");
+    ToDOListClient greeter(grpc::CreateChannel(
+            server_address, grpc::InsecureChannelCredentials()));
+    int i = 0;
+    while (greeter.status.ok() && ++i) {
+        std::cin.clear();
+        if (i% 2 == 0) {
+            std::cout << "Input id" << std::endl;
+            uint32_t id;
+            std::cin >> id;
+            auto resp = greeter.GetTaskByID(id);
+            if (!resp) {
+                std::cout << "bad : no task" << std::endl;
+            } else {
+                std::cout << resp.value().name() << std::endl;
+            }
+        }
+        if (i %2 == 1) {
+            std::cout << "Input task" << std::endl;
+            std::string name;
+            int prior;
+            std::string label;
+            std::string s_date;
+            std::cin >> name >> prior >> label >> s_date;
+            BoostDate date = boost::gregorian::from_simple_string(s_date);
+            TaskData task;
+            task.set_name(name);
+            task.set_prior(static_cast<TaskData::Priority>(prior));
+            task.set_label(label);
+            auto pb_date = proto_convert::GetProtobufDate(date);
+            task.set_allocated_date(pb_date.release());
+            task.set_completed(false);
+            auto resp = greeter.AddTask(task);
+            if (!resp.success()) {
+                std::cout << "bad : " << resp.error_msg() << std::endl;
+            } else {
+                std::cout << resp.created_id().id() << std::endl;
+            }
+        }
+    }
+    return 0;
+}

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -21,60 +21,11 @@ class ToDOListClient {
 
 public:
     explicit ToDOListClient(const std::shared_ptr<Channel>& channel)
-            : stub_(GrpcTaskService::NewStub(channel)), status(Status::OK) {}
+            : stub_(GrpcTaskService::NewStub(channel)) {}
 
-    // Assembles the client's payload, sends it and presents the response back
-    // from the server.
-    std::optional<TaskData> GetTaskByID(uint32_t id) {
-        // Data we are sending to the server.
-        TaskIdMessage request;
-        request.set_id(id);
+    void Run() {
 
-        // Container for the data we expect from the server.
-        GetTaskByIDResponse reply;
-        // Context for the client. It could be used to convey extra information to
-        // the server and/or tweak certain RPC behaviors.
-        ClientContext context;
-
-        // The actual RPC.
-        status = stub_->GetTaskByID(&context, request, &reply);
-
-        // Act upon its status.
-        if (status.ok()) {
-            if (reply.has_task()) {
-                return reply.task();
-            } else {
-                return std::nullopt;
-            }
-        } else {
-            std::cout << status.error_code() << ": " << status.error_message()
-                      << std::endl;
-            return std::nullopt;
-        }
     }
-    AddTaskResponse AddTask(const TaskData& task) {
-        // Data we are sending to the server.
-        const TaskData request = task;
-
-        // Container for the data we expect from the server.
-        AddTaskResponse reply;
-        // Context for the client. It could be used to convey extra information to
-        // the server and/or tweak certain RPC behaviors.
-        ClientContext context;
-
-        // The actual RPC.
-        status = stub_->AddTask(&context, request, &reply);
-
-        // Act upon its status.
-        if (status.ok()) {
-            return reply;
-        } else {
-            std::cout << status.error_code() << ": " << status.error_message()
-                      << std::endl;
-        }
-        return reply;
-    }
-    Status status;
 private:
 
     std::unique_ptr<GrpcTaskService::Stub> stub_;
@@ -83,44 +34,8 @@ private:
 
 int main() {
     std::string server_address("0.0.0.0:50051");
-    ToDOListClient greeter(grpc::CreateChannel(
+    ToDOListClient client(grpc::CreateChannel(
             server_address, grpc::InsecureChannelCredentials()));
-    int i = 0;
-    while (greeter.status.ok() && ++i) {
-        std::cin.clear();
-        if (i% 2 == 0) {
-            std::cout << "Input id" << std::endl;
-            uint32_t id;
-            std::cin >> id;
-            auto resp = greeter.GetTaskByID(id);
-            if (!resp) {
-                std::cout << "bad : no task" << std::endl;
-            } else {
-                std::cout << resp.value().name() << std::endl;
-            }
-        }
-        if (i %2 == 1) {
-            std::cout << "Input task" << std::endl;
-            std::string name;
-            int prior;
-            std::string label;
-            std::string s_date;
-            std::cin >> name >> prior >> label >> s_date;
-            BoostDate date = boost::gregorian::from_simple_string(s_date);
-            TaskData task;
-            task.set_name(name);
-            task.set_prior(static_cast<TaskData::Priority>(prior));
-            task.set_label(label);
-            auto pb_date = proto_convert::GetProtobufDate(date);
-            task.set_allocated_date(pb_date.release());
-            task.set_completed(false);
-            auto resp = greeter.AddTask(task);
-            if (!resp.success()) {
-                std::cout << "bad : " << resp.error_msg() << std::endl;
-            } else {
-                std::cout << resp.created_id().id() << std::endl;
-            }
-        }
-    }
+    client.Run();
     return 0;
 }

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -23,11 +23,7 @@ public:
     explicit ToDOListClient(const std::shared_ptr<Channel>& channel)
             : stub_(GrpcTaskService::NewStub(channel)) {}
 
-    void Run() {
-
-    }
 private:
-
     std::unique_ptr<GrpcTaskService::Stub> stub_;
 };
 
@@ -36,6 +32,5 @@ int main() {
     std::string server_address("0.0.0.0:50051");
     ToDOListClient client(grpc::CreateChannel(
             server_address, grpc::InsecureChannelCredentials()));
-    client.Run();
     return 0;
 }

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -1,0 +1,29 @@
+//
+// Created by denis on 22.10.20.
+//
+
+#include "core/api/GrpcTaskServiceImpl.h"
+
+int main() {
+    std::string server_address("0.0.0.0:50051");
+    grpc::EnableDefaultHealthCheckService(true);
+    grpc::reflection::InitProtoReflectionServerBuilderPlugin();
+    GrpcTaskServiceImpl service(
+            std::make_unique<RepositoryHolder>(
+                    std::make_unique<RepositoryCreator>(),
+                    std::make_unique<PersisterCreator>()));
+    ServerBuilder builder;
+    // Listen on the given address without any authentication mechanism.
+    builder.AddListeningPort(server_address, grpc::InsecureServerCredentials());
+    // Register "service" as the instance through which we'll communicate with
+    // clients. In this case it corresponds to an *synchronous* service.
+    builder.RegisterService(&service);
+    // Finally assemble the server.
+    std::unique_ptr<Server> server(builder.BuildAndStart());
+    std::cout << "Server listening on " << server_address << std::endl;
+
+    // Wait for the server to shutdown. Note that some other thread must be
+    // responsible for shutting down the server for this call to ever return.
+    server->Wait();
+    return 0;
+}

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -4,6 +4,8 @@
 
 #include "core/api/GrpcTaskServiceImpl.h"
 
+using grpc_task_service::GrpcTaskServiceImpl;
+
 int main() {
     std::string server_address("0.0.0.0:50051");
     grpc::EnableDefaultHealthCheckService(true);

--- a/src/core/api/GrpcTaskServiceImpl.cpp
+++ b/src/core/api/GrpcTaskServiceImpl.cpp
@@ -94,7 +94,7 @@ GrpcTaskServiceImpl::AddSubTask(ServerContext* context, const AddSubTaskRequest*
 }
 
 Status
-GrpcTaskServiceImpl::GetAllWithLabel(ServerContext *context, const StringRequest *request, TaskDTOList *response) {
+GrpcTaskServiceImpl::GetAllWithLabel(ServerContext *context, const StringMessage *request, TaskDTOList *response) {
     std::vector<RepositoryTaskDTO> result_set =
             repository_holder_
                 ->GetRepository()
@@ -224,14 +224,14 @@ Status GrpcTaskServiceImpl::CompleteTask(ServerContext *context, const TaskIdMes
     return Status::OK;
 }
 
-Status GrpcTaskServiceImpl::SaveToFile(ServerContext *context, const StringRequest *request, DefaultResponse *response) {
+Status GrpcTaskServiceImpl::SaveToFile(ServerContext *context, const StringMessage *request, DefaultResponse *response) {
     bool saved = repository_holder_->SaveRepositoryToFile(request->str());
     auto result = saved ? RequestResult::success() : RequestResult(false, "Could not save");
     ConvertTogRPC(result, response);
     return Status::OK;
 }
 
-Status GrpcTaskServiceImpl::LoadFromFile(ServerContext *context, const StringRequest *request, DefaultResponse *response) {
+Status GrpcTaskServiceImpl::LoadFromFile(ServerContext *context, const StringMessage *request, DefaultResponse *response) {
     bool loaded = repository_holder_->LoadRepositoryFromFile(request->str());
     auto result = loaded ? RequestResult::success() : RequestResult(false, "Could not load");
     ConvertTogRPC(result, response);

--- a/src/core/api/GrpcTaskServiceImpl.cpp
+++ b/src/core/api/GrpcTaskServiceImpl.cpp
@@ -1,0 +1,68 @@
+//
+// Created by denis on 22.10.20.
+//
+
+#include "GrpcTaskServiceImpl.h"
+
+void ConvertTogRPC(TaskCreationResult& repos_result, AddTaskResponse* response) {
+    bool status =       repos_result.getSuccessStatus();
+    auto error_msg =    repos_result.getErrorMessage();
+    auto id =           repos_result.getCreatedTaskID();
+    response->set_success(status);
+    if (error_msg) {
+        response->set_error_msg(error_msg.value());
+    }
+    if (id) {
+        auto id_msg = std::make_unique<TaskIdMessage>();
+        id_msg->set_id(id.value().getInt());
+        response->set_allocated_created_id(id_msg.release());
+    }
+}
+
+
+GrpcTaskServiceImpl::GrpcTaskServiceImpl(std::unique_ptr<RepositoryHolder>&& repos_holder)
+:
+repository_holder_(std::move(repos_holder))
+{}
+
+Status
+GrpcTaskServiceImpl::GetTaskByID(ServerContext* context, const TaskIdMessage* request, GetTaskByIDResponse* response) {
+    auto repos_result = repository_holder_->GetRepository().getTaskData(TaskID(request->id()));
+    if (repos_result) {
+        if (!proto_convert::WriteToMessage(repos_result.value(), response->mutable_task())) {
+            response->set_allocated_task(nullptr);
+        }
+    }
+    return Status::OK;
+}
+Status
+GrpcTaskServiceImpl::AddTask(ServerContext* context, const TaskData* request, AddTaskResponse* response) {
+    if (!validate_date(proto_convert::RestoreDate(request->date()))) {
+        response->set_success(false);
+        response->set_error_msg("Task date is out of allowed range");
+        return Status::OK;
+    }
+    TaskCreationResult result =
+            repository_holder_
+                    ->GetRepository()
+                    .addTask(proto_convert::RestoreFromMessage(*request));
+    ConvertTogRPC(result, response);
+    return Status::OK;
+}
+Status
+GrpcTaskServiceImpl::AddSubTask(ServerContext* context, const AddSubTaskRequest* request, AddTaskResponse* response) {
+    if (!validate_date(proto_convert::RestoreDate(request->task().date()))) {
+        response->set_success(false);
+        response->set_error_msg("Task date is out of allowed range");
+        return Status::OK;
+    }
+    TaskCreationResult result =
+            repository_holder_
+                    ->GetRepository()
+                    .addSubTask(
+                            TaskID(request->parent().id()),
+                            proto_convert::RestoreFromMessage(request->task()));
+    ConvertTogRPC(result, response);
+    return Status::OK;
+}
+

--- a/src/core/api/GrpcTaskServiceImpl.cpp
+++ b/src/core/api/GrpcTaskServiceImpl.cpp
@@ -19,6 +19,17 @@ void ConvertTogRPC(TaskCreationResult& repos_result, AddTaskResponse* response) 
     }
 }
 
+void ConvertTogRPC(const std::vector<RepositoryTaskDTO>& tasks, TaskDTOList* response) {
+    for (const auto& task : tasks) {
+        GrpcTaskDTO* grpc_dto = response->add_tasks();
+        auto id =         std::make_unique<TaskIdMessage>();
+        auto grpc_task =  std::make_unique<TaskData>();
+        id->set_id(task.getId());
+        grpc_dto->set_allocated_id(id.release());
+        grpc_dto->set_allocated_task(grpc_task.release());
+    }
+}
+
 
 GrpcTaskServiceImpl::GrpcTaskServiceImpl(std::unique_ptr<RepositoryHolder>&& repos_holder)
 :
@@ -66,3 +77,71 @@ GrpcTaskServiceImpl::AddSubTask(ServerContext* context, const AddSubTaskRequest*
     return Status::OK;
 }
 
+Status
+GrpcTaskServiceImpl::GetAllWithLabel(ServerContext *context, const StringRequest *request, TaskDTOList *response) {
+    std::vector<RepositoryTaskDTO> result_set =
+            repository_holder_
+                ->GetRepository()
+                .getWithLabel(request->str());
+    ConvertTogRPC(result_set, response);
+    return Status::OK;
+}
+
+grpc::Status GrpcTaskServiceImpl::GetToday(ServerContext *context, const EmptyRequest *request, TaskDTOList *response) {
+    using boost::gregorian::day_clock;
+    using boost::gregorian::days;
+    std::vector<RepositoryTaskDTO> result_set =
+            repository_holder_
+                    ->GetRepository()
+                    .getToDate(day_clock::local_day());
+    ConvertTogRPC(result_set, response);
+    return Status::OK;
+}
+
+Status
+GrpcTaskServiceImpl::GetThisWeek(ServerContext *context, const EmptyRequest *request, TaskDTOList *response) {
+    using boost::gregorian::day_clock;
+    using boost::gregorian::days;
+    std::vector<RepositoryTaskDTO> result_set =
+            repository_holder_
+                    ->GetRepository()
+                    .getToDate(day_clock::local_day() + days(6));
+    ConvertTogRPC(result_set, response);
+    return Status::OK;
+}
+
+Status
+GrpcTaskServiceImpl::GetAllTasks(ServerContext *context, const EmptyRequest *request, TaskDTOList *response) {
+    using boost::gregorian::day_clock;
+    using boost::gregorian::days;
+    std::vector<RepositoryTaskDTO> result_set =
+            repository_holder_
+                    ->GetRepository()
+                    .getToDate(service::max_date);
+    ConvertTogRPC(result_set, response);
+    return Status::OK;
+}
+
+Status
+GrpcTaskServiceImpl::GetSubTasks(ServerContext *context, const TaskIdMessage *request, TaskDTOList *response) {
+    using boost::gregorian::day_clock;
+    using boost::gregorian::days;
+    std::vector<RepositoryTaskDTO> result_set =
+            repository_holder_
+                    ->GetRepository()
+                    .getSubTasks(TaskID(request->id()));
+    ConvertTogRPC(result_set, response);
+    return Status::OK;
+}
+
+Status
+GrpcTaskServiceImpl::GetSubTasksRecursive(ServerContext *context, const TaskIdMessage *request, TaskDTOList *response) {
+    using boost::gregorian::day_clock;
+    using boost::gregorian::days;
+    std::vector<RepositoryTaskDTO> result_set =
+            repository_holder_
+                    ->GetRepository()
+                    .getSubTasksRecursive(TaskID(request->id()));
+    ConvertTogRPC(result_set, response);
+    return Status::OK;;
+}

--- a/src/core/api/GrpcTaskServiceImpl.cpp
+++ b/src/core/api/GrpcTaskServiceImpl.cpp
@@ -3,8 +3,14 @@
 //
 
 #include "GrpcTaskServiceImpl.h"
+using namespace grpc_task_service;
 
-void ConvertTogRPC(TaskCreationResult& repos_result, AddTaskResponse* response) {
+bool grpc_task_service::validate_date(const BoostDate& date) {
+    return  date <= grpc_task_service::max_date &&
+            date >= boost::gregorian::day_clock::local_day();
+}
+
+void grpc_task_service::ConvertTogRPC(TaskCreationResult& repos_result, AddTaskResponse* response) {
     bool status =       repos_result.getSuccessStatus();
     auto error_msg =    repos_result.getErrorMessage();
     auto id =           repos_result.getCreatedTaskID();
@@ -20,7 +26,7 @@ void ConvertTogRPC(TaskCreationResult& repos_result, AddTaskResponse* response) 
 }
 
 template<class ReposResult>
-void ConvertTogRPC(ReposResult& repos_result, DefaultResponse* response) {
+void grpc_task_service::ConvertTogRPC(ReposResult& repos_result, DefaultResponse* response) {
     bool status =       repos_result.getSuccessStatus();
     auto error_msg =    repos_result.getErrorMessage();
     response->set_success(status);
@@ -29,7 +35,7 @@ void ConvertTogRPC(ReposResult& repos_result, DefaultResponse* response) {
     }
 }
 
-void ConvertTogRPC(const std::vector<RepositoryTaskDTO>& tasks, TaskDTOList* response) {
+void grpc_task_service::ConvertTogRPC(const std::vector<RepositoryTaskDTO>& tasks, TaskDTOList* response) {
     for (const auto& task : tasks) {
         GrpcTaskDTO* grpc_dto = response->add_tasks();
         auto id =         std::make_unique<TaskIdMessage>();
@@ -127,7 +133,7 @@ GrpcTaskServiceImpl::GetAllTasks(ServerContext *context, const EmptyRequest *req
     std::vector<RepositoryTaskDTO> result_set =
             repository_holder_
                     ->GetRepository()
-                    .getToDate(service::max_date);
+                    .getToDate(max_date);
     ConvertTogRPC(result_set, response);
     return Status::OK;
 }

--- a/src/core/api/GrpcTaskServiceImpl.cpp
+++ b/src/core/api/GrpcTaskServiceImpl.cpp
@@ -36,11 +36,13 @@ void grpc_task_service::ConvertTogRPC(ReposResult& repos_result, DefaultResponse
 }
 
 void grpc_task_service::ConvertTogRPC(const std::vector<RepositoryTaskDTO>& tasks, TaskDTOList* response) {
-    for (const auto& task : tasks) {
-        GrpcTaskDTO* grpc_dto = response->add_tasks();
+    for (auto& task : tasks) {
         auto id =         std::make_unique<TaskIdMessage>();
         auto grpc_task =  std::make_unique<TaskData>();
+        proto_convert::WriteToMessage(task, grpc_task.get());
         id->set_id(task.getId());
+
+        GrpcTaskDTO* grpc_dto = response->add_tasks();
         grpc_dto->set_allocated_id(id.release());
         grpc_dto->set_allocated_task(grpc_task.release());
     }

--- a/src/core/api/GrpcTaskServiceImpl.cpp
+++ b/src/core/api/GrpcTaskServiceImpl.cpp
@@ -217,3 +217,17 @@ Status GrpcTaskServiceImpl::CompleteTask(ServerContext *context, const TaskIdMes
     ConvertTogRPC(res_success, response);
     return Status::OK;
 }
+
+Status GrpcTaskServiceImpl::SaveToFile(ServerContext *context, const StringRequest *request, DefaultResponse *response) {
+    bool saved = repository_holder_->SaveRepositoryToFile(request->str());
+    auto result = saved ? RequestResult::success() : RequestResult(false, "Could not save");
+    ConvertTogRPC(result, response);
+    return Status::OK;
+}
+
+Status GrpcTaskServiceImpl::LoadFromFile(ServerContext *context, const StringRequest *request, DefaultResponse *response) {
+    bool loaded = repository_holder_->LoadRepositoryFromFile(request->str());
+    auto result = loaded ? RequestResult::success() : RequestResult(false, "Could not load");
+    ConvertTogRPC(result, response);
+    return Status::OK;
+}

--- a/src/core/api/GrpcTaskServiceImpl.h
+++ b/src/core/api/GrpcTaskServiceImpl.h
@@ -13,12 +13,10 @@
 #include <grpcpp/grpcpp.h>
 #include <grpcpp/health_check_service_interface.h>
 #include <grpcpp/ext/proto_server_reflection_plugin.h>
-#include <core/api/TaskService.h>
 #include <core/RepositoryHolder.h>
 #include <core/persistence/ProtoConvert.h>
 #include "TaskService.grpc.pb.h"
 #include "TaskService.pb.h"
-
 
 
 using grpc::Server;
@@ -26,6 +24,7 @@ using grpc::ServerBuilder;
 using grpc::ServerContext;
 using grpc::Status;
 
+namespace grpc_task_service {
 
 class GrpcTaskServiceImpl final : public GrpcTaskService::Service {
 
@@ -50,9 +49,17 @@ private:
     std::unique_ptr<RepositoryHolder> repository_holder_;
 };
 
+const BoostDate max_date(
+            BoostDate::year_type(3000),
+            BoostDate::month_type(1),
+            BoostDate::day_type(1));
+
 template<class ReposResult>
 void ConvertTogRPC(ReposResult& repos_result, DefaultResponse* response);
 void ConvertTogRPC(TaskCreationResult& repos_result, AddTaskResponse* response);
 void ConvertTogRPC(const std::vector<RepositoryTaskDTO>& tasks, TaskDTOList* response);
+bool validate_date(const BoostDate& date);
+
+}
 
 #endif //TODOLIST_GRPCTASKSERVICEIMPL_H

--- a/src/core/api/GrpcTaskServiceImpl.h
+++ b/src/core/api/GrpcTaskServiceImpl.h
@@ -35,17 +35,21 @@ public:
     Status    AddTask(ServerContext* context, const TaskData* request, AddTaskResponse* response) override;
     Status    AddSubTask(ServerContext* context, const AddSubTaskRequest* request, AddTaskResponse* response) override;
     Status    GetAllWithLabel(ServerContext* context, const StringRequest* request, TaskDTOList* response) override;
-    Status    GetToday(ServerContext* context, const EmptyRequest* request,TaskDTOList* response) override;
-    Status    GetThisWeek(ServerContext* context, const EmptyRequest* request,TaskDTOList* response) override;
-    Status    GetAllTasks(ServerContext* context, const EmptyRequest* request,TaskDTOList* response) override;
-    Status    GetSubTasks(ServerContext* context, const TaskIdMessage* request,TaskDTOList* response) override;
-    Status    GetSubTasksRecursive(ServerContext* context, const TaskIdMessage* request,TaskDTOList* response) override;
+    Status    GetToday(ServerContext* context, const EmptyRequest* request, TaskDTOList* response) override;
+    Status    GetThisWeek(ServerContext* context, const EmptyRequest* request, TaskDTOList* response) override;
+    Status    GetAllTasks(ServerContext* context, const EmptyRequest* request, TaskDTOList* response) override;
+    Status    GetSubTasks(ServerContext* context, const TaskIdMessage* request, TaskDTOList* response) override;
+    Status    GetSubTasksRecursive(ServerContext* context, const TaskIdMessage* request, TaskDTOList* response) override;
+    Status    DeleteTask(ServerContext* context, const TaskIdMessage* request, DefaultResponse* response) override;
+    Status    PostponeTask(ServerContext* context, const PostponeRequest* request, DefaultResponse* response) override;
+    Status    CompleteTask(ServerContext* context, const TaskIdMessage* request, DefaultResponse* response) override;
 
 private:
     std::unique_ptr<RepositoryHolder> repository_holder_;
 };
 
-
+template<class ReposResult>
+void ConvertTogRPC(ReposResult& repos_result, DefaultResponse* response);
 void ConvertTogRPC(TaskCreationResult& repos_result, AddTaskResponse* response);
 void ConvertTogRPC(const std::vector<RepositoryTaskDTO>& tasks, TaskDTOList* response);
 

--- a/src/core/api/GrpcTaskServiceImpl.h
+++ b/src/core/api/GrpcTaskServiceImpl.h
@@ -43,6 +43,8 @@ public:
     Status    DeleteTask(ServerContext* context, const TaskIdMessage* request, DefaultResponse* response) override;
     Status    PostponeTask(ServerContext* context, const PostponeRequest* request, DefaultResponse* response) override;
     Status    CompleteTask(ServerContext* context, const TaskIdMessage* request, DefaultResponse* response) override;
+    Status    SaveToFile(ServerContext* context, const StringRequest* request,DefaultResponse* response) override;
+    Status    LoadFromFile(ServerContext* context, const StringRequest* request,DefaultResponse* response) override;
 
 private:
     std::unique_ptr<RepositoryHolder> repository_holder_;

--- a/src/core/api/GrpcTaskServiceImpl.h
+++ b/src/core/api/GrpcTaskServiceImpl.h
@@ -30,10 +30,10 @@ using grpc::Status;
 class GrpcTaskServiceImpl final : public GrpcTaskService::Service {
 
 public:
-    explicit GrpcTaskServiceImpl(std::unique_ptr<RepositoryHolder>&& repos_holder);
-    Status GetTaskByID(ServerContext* context, const TaskIdMessage* request, GetTaskByIDResponse* response) override;
-    Status AddTask(ServerContext* context, const TaskData* request, AddTaskResponse* response) override;
-    Status AddSubTask(ServerContext* context, const AddSubTaskRequest* request, AddTaskResponse* response) override;
+    explicit  GrpcTaskServiceImpl(std::unique_ptr<RepositoryHolder>&& repos_holder);
+    Status    GetTaskByID(ServerContext* context, const TaskIdMessage* request, GetTaskByIDResponse* response) override;
+    Status    AddTask(ServerContext* context, const TaskData* request, AddTaskResponse* response) override;
+    Status    AddSubTask(ServerContext* context, const AddSubTaskRequest* request, AddTaskResponse* response) override;
 
 private:
     std::unique_ptr<RepositoryHolder> repository_holder_;

--- a/src/core/api/GrpcTaskServiceImpl.h
+++ b/src/core/api/GrpcTaskServiceImpl.h
@@ -33,7 +33,7 @@ public:
     Status    GetTaskByID(ServerContext* context, const TaskIdMessage* request, GetTaskByIDResponse* response) override;
     Status    AddTask(ServerContext* context, const TaskData* request, AddTaskResponse* response) override;
     Status    AddSubTask(ServerContext* context, const AddSubTaskRequest* request, AddTaskResponse* response) override;
-    Status    GetAllWithLabel(ServerContext* context, const StringRequest* request, TaskDTOList* response) override;
+    Status    GetAllWithLabel(ServerContext* context, const StringMessage* request, TaskDTOList* response) override;
     Status    GetToday(ServerContext* context, const EmptyRequest* request, TaskDTOList* response) override;
     Status    GetThisWeek(ServerContext* context, const EmptyRequest* request, TaskDTOList* response) override;
     Status    GetAllTasks(ServerContext* context, const EmptyRequest* request, TaskDTOList* response) override;
@@ -42,8 +42,8 @@ public:
     Status    DeleteTask(ServerContext* context, const TaskIdMessage* request, DefaultResponse* response) override;
     Status    PostponeTask(ServerContext* context, const PostponeRequest* request, DefaultResponse* response) override;
     Status    CompleteTask(ServerContext* context, const TaskIdMessage* request, DefaultResponse* response) override;
-    Status    SaveToFile(ServerContext* context, const StringRequest* request,DefaultResponse* response) override;
-    Status    LoadFromFile(ServerContext* context, const StringRequest* request,DefaultResponse* response) override;
+    Status    SaveToFile(ServerContext* context, const StringMessage* request, DefaultResponse* response) override;
+    Status    LoadFromFile(ServerContext* context, const StringMessage* request, DefaultResponse* response) override;
 
 private:
     std::unique_ptr<RepositoryHolder> repository_holder_;

--- a/src/core/api/GrpcTaskServiceImpl.h
+++ b/src/core/api/GrpcTaskServiceImpl.h
@@ -1,0 +1,45 @@
+//
+// Created by denis on 22.10.20.
+//
+
+#ifndef TODOLIST_GRPCTASKSERVICEIMPL_H
+#define TODOLIST_GRPCTASKSERVICEIMPL_H
+
+
+#include <iostream>
+#include <memory>
+#include <string>
+
+#include <grpcpp/grpcpp.h>
+#include <grpcpp/health_check_service_interface.h>
+#include <grpcpp/ext/proto_server_reflection_plugin.h>
+#include <core/api/TaskService.h>
+#include <core/RepositoryHolder.h>
+#include <core/persistence/ProtoConvert.h>
+#include "TaskService.grpc.pb.h"
+#include "TaskService.pb.h"
+
+
+
+using grpc::Server;
+using grpc::ServerBuilder;
+using grpc::ServerContext;
+using grpc::Status;
+
+
+class GrpcTaskServiceImpl final : public GrpcTaskService::Service {
+
+public:
+    explicit GrpcTaskServiceImpl(std::unique_ptr<RepositoryHolder>&& repos_holder);
+    Status GetTaskByID(ServerContext* context, const TaskIdMessage* request, GetTaskByIDResponse* response) override;
+    Status AddTask(ServerContext* context, const TaskData* request, AddTaskResponse* response) override;
+    Status AddSubTask(ServerContext* context, const AddSubTaskRequest* request, AddTaskResponse* response) override;
+
+private:
+    std::unique_ptr<RepositoryHolder> repository_holder_;
+};
+
+
+void ConvertTogRPC(TaskCreationResult& repos_result, AddTaskResponse* response);
+
+#endif //TODOLIST_GRPCTASKSERVICEIMPL_H

--- a/src/core/api/GrpcTaskServiceImpl.h
+++ b/src/core/api/GrpcTaskServiceImpl.h
@@ -34,6 +34,12 @@ public:
     Status    GetTaskByID(ServerContext* context, const TaskIdMessage* request, GetTaskByIDResponse* response) override;
     Status    AddTask(ServerContext* context, const TaskData* request, AddTaskResponse* response) override;
     Status    AddSubTask(ServerContext* context, const AddSubTaskRequest* request, AddTaskResponse* response) override;
+    Status    GetAllWithLabel(ServerContext* context, const StringRequest* request, TaskDTOList* response) override;
+    Status    GetToday(ServerContext* context, const EmptyRequest* request,TaskDTOList* response) override;
+    Status    GetThisWeek(ServerContext* context, const EmptyRequest* request,TaskDTOList* response) override;
+    Status    GetAllTasks(ServerContext* context, const EmptyRequest* request,TaskDTOList* response) override;
+    Status    GetSubTasks(ServerContext* context, const TaskIdMessage* request,TaskDTOList* response) override;
+    Status    GetSubTasksRecursive(ServerContext* context, const TaskIdMessage* request,TaskDTOList* response) override;
 
 private:
     std::unique_ptr<RepositoryHolder> repository_holder_;
@@ -41,5 +47,6 @@ private:
 
 
 void ConvertTogRPC(TaskCreationResult& repos_result, AddTaskResponse* response);
+void ConvertTogRPC(const std::vector<RepositoryTaskDTO>& tasks, TaskDTOList* response);
 
 #endif //TODOLIST_GRPCTASKSERVICEIMPL_H

--- a/src/core/api/TaskService.cpp
+++ b/src/core/api/TaskService.cpp
@@ -7,6 +7,7 @@
 
 
 bool validate_date(const BoostDate& date) {
+    std::cout << "Validating : " << date << std::endl;
     return  date <= service::max_date &&
             date >= boost::gregorian::day_clock::local_day();
 }

--- a/src/core/api/TaskService.cpp
+++ b/src/core/api/TaskService.cpp
@@ -7,7 +7,6 @@
 
 
 bool validate_date(const BoostDate& date) {
-    std::cout << "Validating : " << date << std::endl;
     return  date <= service::max_date &&
             date >= boost::gregorian::day_clock::local_day();
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,6 +7,7 @@
 using namespace boost::gregorian;
 
 int main() {
+    operator<<(std::cout, std::string("sss"));
     todo_list_cli::createCLI().run();
     return 0;
 }

--- a/tests/core/gRPC/TestGprcTaskService.cpp
+++ b/tests/core/gRPC/TestGprcTaskService.cpp
@@ -1,0 +1,176 @@
+//
+// Created by denis on 25.10.20.
+//
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include "core/api/GrpcTaskServiceImpl.h"
+#include "mocks/CoreMocks.h"
+#include "mocks/MockRepositoryHolder.h"
+
+using ::testing::AnyNumber;
+using ::testing::Return;
+using ::testing::ReturnRef;
+using ::testing::Action;
+using ::testing::NiceMock;
+using ::testing::_;
+using ::testing::Truly;
+using ::testing::StrictMock;
+
+using namespace boost::gregorian;
+
+class GrpcTaskServiceTest : public ::testing::Test {
+
+};
+
+auto DataIsEqual(const TaskData& message) {
+    return Truly([&] (const RepositoryTaskDTO& dto) -> bool {
+        return message.name() == dto.getName();
+    });
+}
+
+
+TEST_F(GrpcTaskServiceTest, ConvertTogRPCTaskCreationResultGood) {
+    auto result = TaskCreationResult::success(TaskID(100500));
+    AddTaskResponse response;
+    ConvertTogRPC(result, &response);
+    ASSERT_EQ(result.getCreatedTaskID()->getInt(), response.created_id().id());
+    ASSERT_TRUE(response.error_msg().empty());
+    ASSERT_TRUE(response.success());
+}
+
+TEST_F(GrpcTaskServiceTest, ConvertTogRPCTaskCreationResultBad) {
+    auto result = TaskCreationResult::error("Severe error!!!");
+    AddTaskResponse response;
+    ConvertTogRPC(result, &response);
+    ASSERT_FALSE(response.has_created_id());
+    ASSERT_EQ(response.error_msg(), result.getErrorMessage());
+    ASSERT_FALSE(response.success());
+}
+
+TEST_F(GrpcTaskServiceTest, TestGetTaskByID) {
+    auto mrh = std::make_unique<MockRepositoryHolder>();
+    StrictMock<MockRepository> mr;
+    EXPECT_CALL(*mrh, GetRepository).Times(1).WillOnce(ReturnRef(mr));
+    EXPECT_CALL(mr, getTaskData(TaskID(1))).Times(1);
+    GrpcTaskServiceImpl service(std::move(mrh));
+    TaskIdMessage id;
+    id.set_id(1);
+    GetTaskByIDResponse response;
+    EXPECT_EQ(service.GetTaskByID(nullptr, &id, &response).ok(), true);
+}
+
+void TestTaskWithDate(BoostDate date, bool must_be_added) {
+    auto mr = std::make_unique<MockRepository>();
+    auto mrh = std::make_unique<MockRepositoryHolder>();
+    EXPECT_CALL(*mrh, GetRepository).WillRepeatedly(ReturnRef(*mr));
+    EXPECT_CALL(*mr, addTask).Times(must_be_added)
+        .WillOnce(Return(TaskCreationResult::success(TaskID(0))));
+    EXPECT_CALL(*mr, addSubTask).Times(must_be_added)
+            .WillOnce(Return(TaskCreationResult::success(TaskID(0))));
+
+
+    GrpcTaskServiceImpl ts = GrpcTaskServiceImpl(std::move(mrh));
+
+    auto task_with_this_date = RepositoryTaskDTO::create(
+            "nm",
+            TaskPriority::FIRST,
+            "lb",
+            date);
+    TaskData request;
+    AddSubTaskRequest request2;
+    AddTaskResponse response;
+
+    proto_convert::WriteToMessage(
+                task_with_this_date,
+                &request);
+    request2.set_allocated_task(new TaskData);
+    proto_convert::WriteToMessage(
+            task_with_this_date,
+            request2.mutable_task());
+
+    EXPECT_EQ(ts.AddTask(nullptr, &request, &response).ok(), true);
+    EXPECT_EQ(ts.AddSubTask(nullptr, &request2, &response).ok(), true);
+}
+
+TEST_F(GrpcTaskServiceTest, TestTaskWithDateBiggerThenMaxNotAdded) {
+    TestTaskWithDate(service::max_date + days(1), false);
+}
+
+TEST_F(GrpcTaskServiceTest, TestTaskWithDateBeforeTodayNotAdded) {
+    TestTaskWithDate(boost::gregorian::day_clock::local_day() - days(1), false);
+}
+
+TEST_F(GrpcTaskServiceTest, TestTaskWithUncceptableDatesAdded) {
+    TestTaskWithDate(service::max_date + days(365), false);
+    TestTaskWithDate(service::max_date + days(366), false);
+    TestTaskWithDate(day_clock::local_day() - days(6), false);
+    TestTaskWithDate(day_clock::local_day() - days(365), false);
+    TestTaskWithDate(day_clock::local_day() - days(366), false);
+}
+
+TEST_F(GrpcTaskServiceTest, TestTaskTodayAdded) {
+    TestTaskWithDate(boost::gregorian::day_clock::local_day() , true);
+}
+
+TEST_F(GrpcTaskServiceTest, TestTaskMaxDayAdded) {
+    TestTaskWithDate(service::max_date, true);
+}
+
+TEST_F(GrpcTaskServiceTest, TestTaskWithAcceptableDatesAdded) {
+    TestTaskWithDate(service::max_date - days(1), true);
+    TestTaskWithDate(day_clock::local_day() + days(6), true);
+    TestTaskWithDate(day_clock::local_day() + days(8), true);
+}
+
+TEST_F(GrpcTaskServiceTest, AddTaskCalledWithAppropriateData) {
+    auto test_task =
+            RepositoryTaskDTO::create(
+                    "nm",
+                    TaskPriority::FIRST,
+                    "lb",
+                    day_clock::local_day());
+    TaskData request;
+    AddTaskResponse response;
+    proto_convert::WriteToMessage(
+            test_task,
+            &request);
+
+    auto mr = std::make_unique<MockRepository>();
+    auto mrh = std::make_unique<MockRepositoryHolder>();
+    EXPECT_CALL(*mrh, GetRepository).WillRepeatedly(ReturnRef(*mr));
+    EXPECT_CALL(*mr, addTask(DataIsEqual(request))).Times(1)
+            .WillOnce(Return(TaskCreationResult::success(TaskID(0))));
+
+    GrpcTaskServiceImpl ts = GrpcTaskServiceImpl(std::move(mrh));
+    EXPECT_TRUE(ts.AddTask(nullptr, &request, &response).ok());
+}
+
+TEST_F(GrpcTaskServiceTest, AddSubTaskCalledWithAppropriateData) {
+    // Test data
+    auto test_task =
+            RepositoryTaskDTO::create(
+                    "nm",
+                    TaskPriority::FIRST,
+                    "lb",
+                    day_clock::local_day());
+    TaskID test_parent(1);
+    AddSubTaskRequest request;
+    AddTaskResponse response;
+    request.set_allocated_task(new TaskData);
+    request.set_allocated_parent(new TaskIdMessage);
+    request.mutable_parent()->set_id(test_parent);
+    proto_convert::WriteToMessage(
+            test_task,
+            request.mutable_task());
+    // Mocks
+    auto mr = std::make_unique<MockRepository>();
+    auto mrh = std::make_unique<MockRepositoryHolder>();
+    EXPECT_CALL(*mrh, GetRepository).WillRepeatedly(ReturnRef(*mr));
+    EXPECT_CALL(*mr, addSubTask(test_parent, DataIsEqual(request.task()))).Times(1)
+            .WillOnce(Return(TaskCreationResult::success(TaskID(0))));
+
+    // Test call
+    GrpcTaskServiceImpl ts = GrpcTaskServiceImpl(std::move(mrh));
+    EXPECT_TRUE(ts.AddSubTask(nullptr, &request, &response).ok());
+}

--- a/tests/core/gRPC/TestGprcTaskService.cpp
+++ b/tests/core/gRPC/TestGprcTaskService.cpp
@@ -18,6 +18,7 @@ using ::testing::Truly;
 using ::testing::StrictMock;
 
 using namespace boost::gregorian;
+using namespace grpc_task_service;
 
 class GrpcTaskServiceTest : public ::testing::Test {
 
@@ -99,7 +100,7 @@ void TestTaskWithDate(BoostDate date, bool must_be_added) {
 }
 
 TEST_F(GrpcTaskServiceTest, TestTaskWithDateBiggerThenMaxNotAdded) {
-    TestTaskWithDate(service::max_date + days(1), false);
+    TestTaskWithDate(grpc_task_service::max_date + days(1), false);
 }
 
 TEST_F(GrpcTaskServiceTest, TestTaskWithDateBeforeTodayNotAdded) {
@@ -107,8 +108,8 @@ TEST_F(GrpcTaskServiceTest, TestTaskWithDateBeforeTodayNotAdded) {
 }
 
 TEST_F(GrpcTaskServiceTest, TestTaskWithUncceptableDatesAdded) {
-    TestTaskWithDate(service::max_date + days(365), false);
-    TestTaskWithDate(service::max_date + days(366), false);
+    TestTaskWithDate(grpc_task_service::max_date + days(365), false);
+    TestTaskWithDate(grpc_task_service::max_date + days(366), false);
     TestTaskWithDate(day_clock::local_day() - days(6), false);
     TestTaskWithDate(day_clock::local_day() - days(365), false);
     TestTaskWithDate(day_clock::local_day() - days(366), false);
@@ -119,11 +120,11 @@ TEST_F(GrpcTaskServiceTest, TestTaskTodayAdded) {
 }
 
 TEST_F(GrpcTaskServiceTest, TestTaskMaxDayAdded) {
-    TestTaskWithDate(service::max_date, true);
+    TestTaskWithDate(grpc_task_service::max_date, true);
 }
 
 TEST_F(GrpcTaskServiceTest, TestTaskWithAcceptableDatesAdded) {
-    TestTaskWithDate(service::max_date - days(1), true);
+    TestTaskWithDate(grpc_task_service::max_date - days(1), true);
     TestTaskWithDate(day_clock::local_day() + days(6), true);
     TestTaskWithDate(day_clock::local_day() + days(8), true);
 }
@@ -225,7 +226,7 @@ TEST_F(GrpcTaskServiceTest, TestGetAllTasks) {
     auto mm = std::make_unique<MockRepository>();
     auto mmh = std::make_unique<MockRepositoryHolder>();
     EXPECT_CALL(*mmh, GetRepository).WillRepeatedly(ReturnRef(*mm));
-    EXPECT_CALL(*mm, getToDate(service::max_date)).Times(1);
+    EXPECT_CALL(*mm, getToDate(grpc_task_service::max_date)).Times(1);
     GrpcTaskServiceImpl ts = GrpcTaskServiceImpl(std::move(mmh));
     EmptyRequest request;
     TaskDTOList response;

--- a/tests/core/gRPC/TestGprcTaskService.cpp
+++ b/tests/core/gRPC/TestGprcTaskService.cpp
@@ -482,7 +482,70 @@ TEST_F(GrpcTaskServiceTest, TestCompleteNotExistingTask) {
     EXPECT_FALSE(response.success());
 }
 
+TEST_F(GrpcTaskServiceTest, TestLoadFromFileReturnsSuccess) {
+    auto mm = std::make_unique<MockRepository>();
+    auto mmh = std::make_unique<MockRepositoryHolder>();
+    EXPECT_CALL(*mmh, GetRepository).WillRepeatedly(ReturnRef(*mm));
 
+    std::string filepath = "abacabadabacaba";
+    EXPECT_CALL(*mmh, LoadRepositoryFromFile(filepath)).Times(1).WillOnce(Return(true));
 
+    GrpcTaskServiceImpl ts = GrpcTaskServiceImpl(std::move(mmh));
+    StringRequest request;
+    request.set_str(filepath);
+    DefaultResponse response;
 
+    EXPECT_TRUE(ts.LoadFromFile(nullptr, &request, &response).ok());
+    EXPECT_TRUE(response.success());
+}
 
+TEST_F(GrpcTaskServiceTest, TestLoadFromFileReturnsErrorOnFail) {
+    auto mm = std::make_unique<MockRepository>();
+    auto mmh = std::make_unique<MockRepositoryHolder>();
+    EXPECT_CALL(*mmh, GetRepository).WillRepeatedly(ReturnRef(*mm));
+
+    std::string filepath = "abacabadabacaba";
+    EXPECT_CALL(*mmh, LoadRepositoryFromFile(filepath)).Times(1).WillOnce(Return(false));
+
+    GrpcTaskServiceImpl ts = GrpcTaskServiceImpl(std::move(mmh));
+    StringRequest request;
+    request.set_str(filepath);
+    DefaultResponse response;
+
+    EXPECT_TRUE(ts.LoadFromFile(nullptr, &request, &response).ok());
+    EXPECT_FALSE(response.success());
+}
+
+TEST_F(GrpcTaskServiceTest, TestSaveToFileReturnsSuccess) {
+    auto mm = std::make_unique<MockRepository>();
+    auto mmh = std::make_unique<MockRepositoryHolder>();
+    EXPECT_CALL(*mmh, GetRepository).WillRepeatedly(ReturnRef(*mm));
+
+    std::string filepath = "abacabadabacaba";
+    EXPECT_CALL(*mmh, SaveRepositoryToFile(filepath)).Times(1).WillOnce(Return(true));
+
+    GrpcTaskServiceImpl ts = GrpcTaskServiceImpl(std::move(mmh));
+    StringRequest request;
+    request.set_str(filepath);
+    DefaultResponse response;
+
+    EXPECT_TRUE(ts.SaveToFile(nullptr, &request, &response).ok());
+    EXPECT_TRUE(response.success());
+}
+
+TEST_F(GrpcTaskServiceTest, TestSaveToFileReturnsErrorOnFail) {
+    auto mm = std::make_unique<MockRepository>();
+    auto mmh = std::make_unique<MockRepositoryHolder>();
+    EXPECT_CALL(*mmh, GetRepository).WillRepeatedly(ReturnRef(*mm));
+
+    std::string filepath = "abacabadabacaba";
+    EXPECT_CALL(*mmh, SaveRepositoryToFile(filepath)).Times(1).WillOnce(Return(false));
+
+    GrpcTaskServiceImpl ts = GrpcTaskServiceImpl(std::move(mmh));
+    StringRequest request;
+    request.set_str(filepath);
+    DefaultResponse response;
+
+    EXPECT_TRUE(ts.SaveToFile(nullptr, &request, &response).ok());
+    EXPECT_FALSE(response.success());
+}

--- a/tests/core/gRPC/TestGprcTaskService.cpp
+++ b/tests/core/gRPC/TestGprcTaskService.cpp
@@ -174,3 +174,78 @@ TEST_F(GrpcTaskServiceTest, AddSubTaskCalledWithAppropriateData) {
     GrpcTaskServiceImpl ts = GrpcTaskServiceImpl(std::move(mrh));
     EXPECT_TRUE(ts.AddSubTask(nullptr, &request, &response).ok());
 }
+
+
+TEST_F(GrpcTaskServiceTest, TestGetSubtasks) {
+    TaskID root(9);
+    auto mm = std::make_unique<MockRepository>();
+    auto mmh = std::make_unique<MockRepositoryHolder>();
+    EXPECT_CALL(*mmh, GetRepository).WillRepeatedly(ReturnRef(*mm));
+    EXPECT_CALL(*mm, getSubTasks(root)).Times(1);
+    GrpcTaskServiceImpl ts = GrpcTaskServiceImpl(std::move(mmh));
+    TaskIdMessage request;
+    TaskDTOList response;
+    request.set_id(root);
+    ts.GetSubTasks(nullptr, &request, &response);
+}
+
+TEST_F(GrpcTaskServiceTest, TestGetSubtasksRecursive) {
+    TaskID root(9);
+    auto mm = std::make_unique<MockRepository>();
+    auto mmh = std::make_unique<MockRepositoryHolder>();
+    EXPECT_CALL(*mmh, GetRepository).WillRepeatedly(ReturnRef(*mm));
+    EXPECT_CALL(*mm, getSubTasksRecursive(root)).Times(1);
+    GrpcTaskServiceImpl ts = GrpcTaskServiceImpl(std::move(mmh));
+    TaskIdMessage request;
+    TaskDTOList response;
+    request.set_id(root);
+    ts.GetSubTasksRecursive(nullptr, &request, &response);
+}
+
+TEST_F(GrpcTaskServiceTest, TestGetByLabel) {
+    auto mm = std::make_unique<MockRepository>();
+    auto mmh = std::make_unique<MockRepositoryHolder>();
+    EXPECT_CALL(*mmh, GetRepository).WillRepeatedly(ReturnRef(*mm));
+    EXPECT_CALL(*mm, getWithLabel("label")).Times(1);
+    GrpcTaskServiceImpl ts = GrpcTaskServiceImpl(std::move(mmh));
+    StringRequest request;
+    request.set_str("label");
+    TaskDTOList response;
+    ts.GetAllWithLabel(nullptr, &request, &response);
+}
+
+
+TEST_F(GrpcTaskServiceTest, TestGetAllTasks) {
+    TaskID root(9);
+    auto mm = std::make_unique<MockRepository>();
+    auto mmh = std::make_unique<MockRepositoryHolder>();
+    EXPECT_CALL(*mmh, GetRepository).WillRepeatedly(ReturnRef(*mm));
+    EXPECT_CALL(*mm, getToDate(service::max_date)).Times(1);
+    GrpcTaskServiceImpl ts = GrpcTaskServiceImpl(std::move(mmh));
+    EmptyRequest request;
+    TaskDTOList response;
+    ts.GetAllTasks(nullptr, &request, &response);
+}
+
+TEST_F(GrpcTaskServiceTest, TestGetThisWeek) {
+    auto mm = std::make_unique<MockRepository>();
+    auto mmh = std::make_unique<MockRepositoryHolder>();
+    EXPECT_CALL(*mmh, GetRepository).WillRepeatedly(ReturnRef(*mm));
+    EXPECT_CALL(*mm, getToDate(day_clock::local_day() + days(6))).Times(1);
+    GrpcTaskServiceImpl ts = GrpcTaskServiceImpl(std::move(mmh));
+    EmptyRequest request;
+    TaskDTOList response;
+    ts.GetThisWeek(nullptr, &request, &response);
+}
+
+TEST_F(GrpcTaskServiceTest, TestGetToday) {
+    auto mm = std::make_unique<MockRepository>();
+    auto mmh = std::make_unique<MockRepositoryHolder>();
+    EXPECT_CALL(*mmh, GetRepository).WillRepeatedly(ReturnRef(*mm));
+    EXPECT_CALL(*mm, getToDate(day_clock::local_day())).Times(1);
+    GrpcTaskServiceImpl ts = GrpcTaskServiceImpl(std::move(mmh));
+    EmptyRequest request;
+    TaskDTOList response;
+    ts.GetToday(nullptr, &request, &response);
+}
+

--- a/tests/core/gRPC/TestGprcTaskService.cpp
+++ b/tests/core/gRPC/TestGprcTaskService.cpp
@@ -214,7 +214,7 @@ TEST_F(GrpcTaskServiceTest, TestGetByLabel) {
     EXPECT_CALL(*mmh, GetRepository).WillRepeatedly(ReturnRef(*mm));
     EXPECT_CALL(*mm, getWithLabel("label")).Times(1);
     GrpcTaskServiceImpl ts = GrpcTaskServiceImpl(std::move(mmh));
-    StringRequest request;
+    StringMessage request;
     request.set_str("label");
     TaskDTOList response;
     EXPECT_TRUE(ts.GetAllWithLabel(nullptr, &request, &response).ok());
@@ -492,7 +492,7 @@ TEST_F(GrpcTaskServiceTest, TestLoadFromFileReturnsSuccess) {
     EXPECT_CALL(*mmh, LoadRepositoryFromFile(filepath)).Times(1).WillOnce(Return(true));
 
     GrpcTaskServiceImpl ts = GrpcTaskServiceImpl(std::move(mmh));
-    StringRequest request;
+    StringMessage request;
     request.set_str(filepath);
     DefaultResponse response;
 
@@ -509,7 +509,7 @@ TEST_F(GrpcTaskServiceTest, TestLoadFromFileReturnsErrorOnFail) {
     EXPECT_CALL(*mmh, LoadRepositoryFromFile(filepath)).Times(1).WillOnce(Return(false));
 
     GrpcTaskServiceImpl ts = GrpcTaskServiceImpl(std::move(mmh));
-    StringRequest request;
+    StringMessage request;
     request.set_str(filepath);
     DefaultResponse response;
 
@@ -526,7 +526,7 @@ TEST_F(GrpcTaskServiceTest, TestSaveToFileReturnsSuccess) {
     EXPECT_CALL(*mmh, SaveRepositoryToFile(filepath)).Times(1).WillOnce(Return(true));
 
     GrpcTaskServiceImpl ts = GrpcTaskServiceImpl(std::move(mmh));
-    StringRequest request;
+    StringMessage request;
     request.set_str(filepath);
     DefaultResponse response;
 
@@ -543,7 +543,7 @@ TEST_F(GrpcTaskServiceTest, TestSaveToFileReturnsErrorOnFail) {
     EXPECT_CALL(*mmh, SaveRepositoryToFile(filepath)).Times(1).WillOnce(Return(false));
 
     GrpcTaskServiceImpl ts = GrpcTaskServiceImpl(std::move(mmh));
-    StringRequest request;
+    StringMessage request;
     request.set_str(filepath);
     DefaultResponse response;
 


### PR DESCRIPTION
Add gRPC library to project.
Add custom cmake command for generating TaskService.grpc.pb.h, TaskService.grpc.pb.cc, TaskService.pb.h, TaskService.h files.
Add .proto description of gRPC task service implementation based on **TaskServiceInterface**.
Implement its all methods referring to **TaskService** class. Add functions of convertation **TaskRepository** request results to GrpcTaskService responses.
Test all the stuff.
Create namespace grpc_task_service wrapping **GrpcTaskServiceImpl** class and all helper functions.